### PR TITLE
feat(models): add Activity model with Freezed and unit tests

### DIFF
--- a/lib/data/models/activity.dart
+++ b/lib/data/models/activity.dart
@@ -1,0 +1,57 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'activity.freezed.dart';
+part 'activity.g.dart';
+
+/// Represents an activity that can be assigned to a meeting.
+/// Examples: Coffee, Walk, Cinema, Board Games.
+///
+/// Activities can be global (isGlobal: true, userId: null) - managed via
+/// Firebase Console and read-only for users, or private (isGlobal: false,
+/// userId: String) - created and managed by individual users.
+@freezed
+class Activity with _$Activity {
+  const Activity._();
+
+  const factory Activity({
+    required String id,
+    required String? userId,
+    required String name,
+    required bool isGlobal,
+    required DateTime createdAt,
+    String? categoryId,
+  }) = _Activity;
+
+  factory Activity.fromJson(Map<String, dynamic> json) =>
+      _$ActivityFromJson(json);
+
+  /// Creates an Activity from a Firestore document.
+  factory Activity.fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    return Activity(
+      id: doc.id,
+      userId: data['userId'] as String?,
+      name: (data['name'] ?? '') as String,
+      isGlobal: (data['isGlobal'] ?? false) as bool,
+      categoryId: data['categoryId'] as String?,
+      createdAt: (data['createdAt'] as Timestamp).toDate(),
+    );
+  }
+
+  /// Converts Activity to a map for Firestore storage.
+  Map<String, dynamic> toFirestore() {
+    return {
+      if (userId != null) 'userId': userId,
+      'name': name,
+      'isGlobal': isGlobal,
+      if (categoryId != null) 'categoryId': categoryId,
+      'createdAt': Timestamp.fromDate(createdAt),
+    };
+  }
+
+  /// Returns true if the activity has valid data.
+  bool isValid() {
+    return name.trim().isNotEmpty;
+  }
+}

--- a/lib/data/models/activity.freezed.dart
+++ b/lib/data/models/activity.freezed.dart
@@ -1,0 +1,273 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'activity.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+Activity _$ActivityFromJson(Map<String, dynamic> json) {
+  return _Activity.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Activity {
+  String get id => throw _privateConstructorUsedError;
+  String? get userId => throw _privateConstructorUsedError;
+  String get name => throw _privateConstructorUsedError;
+  bool get isGlobal => throw _privateConstructorUsedError;
+  DateTime get createdAt => throw _privateConstructorUsedError;
+  String? get categoryId => throw _privateConstructorUsedError;
+
+  /// Serializes this Activity to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of Activity
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ActivityCopyWith<Activity> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ActivityCopyWith<$Res> {
+  factory $ActivityCopyWith(Activity value, $Res Function(Activity) then) =
+      _$ActivityCopyWithImpl<$Res, Activity>;
+  @useResult
+  $Res call(
+      {String id,
+      String? userId,
+      String name,
+      bool isGlobal,
+      DateTime createdAt,
+      String? categoryId});
+}
+
+/// @nodoc
+class _$ActivityCopyWithImpl<$Res, $Val extends Activity>
+    implements $ActivityCopyWith<$Res> {
+  _$ActivityCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of Activity
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? userId = freezed,
+    Object? name = null,
+    Object? isGlobal = null,
+    Object? createdAt = null,
+    Object? categoryId = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      userId: freezed == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      isGlobal: null == isGlobal
+          ? _value.isGlobal
+          : isGlobal // ignore: cast_nullable_to_non_nullable
+              as bool,
+      createdAt: null == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      categoryId: freezed == categoryId
+          ? _value.categoryId
+          : categoryId // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ActivityImplCopyWith<$Res>
+    implements $ActivityCopyWith<$Res> {
+  factory _$$ActivityImplCopyWith(
+          _$ActivityImpl value, $Res Function(_$ActivityImpl) then) =
+      __$$ActivityImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String? userId,
+      String name,
+      bool isGlobal,
+      DateTime createdAt,
+      String? categoryId});
+}
+
+/// @nodoc
+class __$$ActivityImplCopyWithImpl<$Res>
+    extends _$ActivityCopyWithImpl<$Res, _$ActivityImpl>
+    implements _$$ActivityImplCopyWith<$Res> {
+  __$$ActivityImplCopyWithImpl(
+      _$ActivityImpl _value, $Res Function(_$ActivityImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of Activity
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? userId = freezed,
+    Object? name = null,
+    Object? isGlobal = null,
+    Object? createdAt = null,
+    Object? categoryId = freezed,
+  }) {
+    return _then(_$ActivityImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      userId: freezed == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      isGlobal: null == isGlobal
+          ? _value.isGlobal
+          : isGlobal // ignore: cast_nullable_to_non_nullable
+              as bool,
+      createdAt: null == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      categoryId: freezed == categoryId
+          ? _value.categoryId
+          : categoryId // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ActivityImpl extends _Activity {
+  const _$ActivityImpl(
+      {required this.id,
+      required this.userId,
+      required this.name,
+      required this.isGlobal,
+      required this.createdAt,
+      this.categoryId})
+      : super._();
+
+  factory _$ActivityImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ActivityImplFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String? userId;
+  @override
+  final String name;
+  @override
+  final bool isGlobal;
+  @override
+  final DateTime createdAt;
+  @override
+  final String? categoryId;
+
+  @override
+  String toString() {
+    return 'Activity(id: $id, userId: $userId, name: $name, isGlobal: $isGlobal, createdAt: $createdAt, categoryId: $categoryId)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ActivityImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.userId, userId) || other.userId == userId) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.isGlobal, isGlobal) ||
+                other.isGlobal == isGlobal) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.categoryId, categoryId) ||
+                other.categoryId == categoryId));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, id, userId, name, isGlobal, createdAt, categoryId);
+
+  /// Create a copy of Activity
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ActivityImplCopyWith<_$ActivityImpl> get copyWith =>
+      __$$ActivityImplCopyWithImpl<_$ActivityImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ActivityImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _Activity extends Activity {
+  const factory _Activity(
+      {required final String id,
+      required final String? userId,
+      required final String name,
+      required final bool isGlobal,
+      required final DateTime createdAt,
+      final String? categoryId}) = _$ActivityImpl;
+  const _Activity._() : super._();
+
+  factory _Activity.fromJson(Map<String, dynamic> json) =
+      _$ActivityImpl.fromJson;
+
+  @override
+  String get id;
+  @override
+  String? get userId;
+  @override
+  String get name;
+  @override
+  bool get isGlobal;
+  @override
+  DateTime get createdAt;
+  @override
+  String? get categoryId;
+
+  /// Create a copy of Activity
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ActivityImplCopyWith<_$ActivityImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/data/models/activity.g.dart
+++ b/lib/data/models/activity.g.dart
@@ -1,0 +1,35 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'activity.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ActivityImpl _$$ActivityImplFromJson(Map<String, dynamic> json) =>
+    $checkedCreate(
+      r'_$ActivityImpl',
+      json,
+      ($checkedConvert) {
+        final val = _$ActivityImpl(
+          id: $checkedConvert('id', (v) => v as String),
+          userId: $checkedConvert('userId', (v) => v as String?),
+          name: $checkedConvert('name', (v) => v as String),
+          isGlobal: $checkedConvert('isGlobal', (v) => v as bool),
+          createdAt:
+              $checkedConvert('createdAt', (v) => DateTime.parse(v as String)),
+          categoryId: $checkedConvert('categoryId', (v) => v as String?),
+        );
+        return val;
+      },
+    );
+
+Map<String, dynamic> _$$ActivityImplToJson(_$ActivityImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'userId': instance.userId,
+      'name': instance.name,
+      'isGlobal': instance.isGlobal,
+      'createdAt': instance.createdAt.toIso8601String(),
+      'categoryId': instance.categoryId,
+    };

--- a/test/data/models/activity_test.dart
+++ b/test/data/models/activity_test.dart
@@ -1,0 +1,161 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:friendsheet/data/models/activity.dart';
+
+void main() {
+  group('Activity Model Tests', () {
+    // Helper: creates a valid private activity
+    Activity createPrivateActivity({
+      String id = 'activity-1',
+      String userId = 'user-123',
+      String name = 'Coffee',
+      String? categoryId,
+    }) {
+      return Activity(
+        id: id,
+        userId: userId,
+        name: name,
+        isGlobal: false,
+        categoryId: categoryId,
+        createdAt: DateTime(2026, 2, 19),
+      );
+    }
+
+    // Helper: creates a valid global activity
+    Activity createGlobalActivity({
+      String id = 'global-activity-1',
+      String name = 'Walk',
+      String? categoryId,
+    }) {
+      return Activity(
+        id: id,
+        userId: null,
+        name: name,
+        isGlobal: true,
+        categoryId: categoryId,
+        createdAt: DateTime(2026, 2, 19),
+      );
+    }
+
+    group('isValid()', () {
+      test('returns true for activity with non-empty name', () {
+        final activity = createPrivateActivity(name: 'Coffee');
+        expect(activity.isValid(), isTrue);
+      });
+
+      test('returns false for activity with empty name', () {
+        final activity = createPrivateActivity(name: '');
+        expect(activity.isValid(), isFalse);
+      });
+
+      test('returns false for activity with whitespace-only name', () {
+        final activity = createPrivateActivity(name: '   ');
+        expect(activity.isValid(), isFalse);
+      });
+
+      test('returns true for global activity', () {
+        final activity = createGlobalActivity(name: 'Walk');
+        expect(activity.isValid(), isTrue);
+      });
+    });
+
+    group('Global vs Private', () {
+      test('global activity has null userId', () {
+        final activity = createGlobalActivity();
+        expect(activity.userId, isNull);
+        expect(activity.isGlobal, isTrue);
+      });
+
+      test('private activity has non-null userId', () {
+        final activity = createPrivateActivity();
+        expect(activity.userId, equals('user-123'));
+        expect(activity.isGlobal, isFalse);
+      });
+    });
+
+    group('categoryId', () {
+      test('categoryId is null when not provided', () {
+        final activity = createPrivateActivity();
+        expect(activity.categoryId, isNull);
+      });
+
+      test('categoryId is set when provided', () {
+        final activity = createPrivateActivity(categoryId: 'sport-category');
+        expect(activity.categoryId, equals('sport-category'));
+      });
+    });
+
+    group('copyWith()', () {
+      test('copyWith updates name correctly', () {
+        final activity = createPrivateActivity(name: 'Coffee');
+        final updated = activity.copyWith(name: 'Tea');
+        expect(updated.name, equals('Tea'));
+        expect(updated.id, equals(activity.id));
+      });
+
+      test('copyWith assigns categoryId', () {
+        final activity = createPrivateActivity();
+        final updated = activity.copyWith(categoryId: 'sport-1');
+        expect(updated.categoryId, equals('sport-1'));
+      });
+    });
+
+    group('Equality (==)', () {
+      test('two activities with same data are equal', () {
+        final a1 = createPrivateActivity();
+        final a2 = createPrivateActivity();
+        expect(a1, equals(a2));
+      });
+
+      test('activities with different names are not equal', () {
+        final a1 = createPrivateActivity(name: 'Coffee');
+        final a2 = createPrivateActivity(name: 'Tea');
+        expect(a1, isNot(equals(a2)));
+      });
+    });
+
+    group('JSON serialization', () {
+      test('toJson and fromJson round-trip works correctly', () {
+        final activity = createPrivateActivity(categoryId: 'sport-1');
+        final json = activity.toJson();
+        final restored = Activity.fromJson(json);
+        expect(restored, equals(activity));
+      });
+
+      test('toJson round-trip works for global activity', () {
+        final activity = createGlobalActivity();
+        final json = activity.toJson();
+        final restored = Activity.fromJson(json);
+        expect(restored, equals(activity));
+      });
+    });
+
+    group('toFirestore()', () {
+      test('private activity includes userId in map', () {
+        final activity = createPrivateActivity();
+        final map = activity.toFirestore();
+        expect(map['userId'], equals('user-123'));
+        expect(map['name'], equals('Coffee'));
+        expect(map['isGlobal'], isFalse);
+      });
+
+      test('global activity omits userId from map', () {
+        final activity = createGlobalActivity();
+        final map = activity.toFirestore();
+        expect(map.containsKey('userId'), isFalse);
+        expect(map['isGlobal'], isTrue);
+      });
+
+      test('categoryId omitted from map when null', () {
+        final activity = createPrivateActivity();
+        final map = activity.toFirestore();
+        expect(map.containsKey('categoryId'), isFalse);
+      });
+
+      test('categoryId included in map when set', () {
+        final activity = createPrivateActivity(categoryId: 'sport-1');
+        final map = activity.toFirestore();
+        expect(map['categoryId'], equals('sport-1'));
+      });
+    });
+  });
+}


### PR DESCRIPTION
- Add Activity model with isGlobal and categoryId fields
- Support global (userId: null) and private (userId: String) activities
- Implement fromFirestore, toFirestore, fromJson, toJson
- Add isValid() validation (name non-empty)
- Write 13 unit tests covering validation, equality, serialization

Closes #9