### PR TITLE
feat: add ActivityCategory model and repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 | M7 | Custom Dashboard | 📋 Planned |
 | M8 | AI Assistant | 💡 Future |
 
-**M2 — Management & CRUD:** Full CRUD for meetings, persons and activities. Meetings list grouped by year (collapsed for older years). Activity categories with icons and 3-level hierarchy.
+**M2 — Management & CRUD:** Full CRUD for meetings, persons and activities. Meetings list grouped by year (collapsed for older years). Activity categories with icons and 2-level hierarchy.
 
 **M3 — Statistics & Export:** Person frequency stats, activity stats with category hierarchy filtering, "haven't seen in a while" alerts, JSON data export.
 
@@ -133,8 +133,7 @@ flutter format --set-exit-if-changed .
 
 **Current Test Status:**
 ```
-✅ All tests passing (166)
-✅ No linting issues
+✅ All tests passing (214)
 ✅ Code formatted correctly
 ✅ Firebase connected successfully
 ✅ CI/CD pipeline operational
@@ -220,6 +219,15 @@ Project Link: [https://github.com/aleksanderginalski/friendsheet-app](https://gi
 **Note:** This is a learning project to understand SDLC (Software Development Life Cycle) and mobile app development with Flutter.
 
 ## 📖 Version History
+
+### v2.5.0 - US-019 Activity Categories (February 24, 2026)
+- ✅ ActivityCategory model with Freezed (7 fields: id, userId, name, iconIdentifier, isGlobal, parentCategoryId, createdAt)
+- ✅ ActivityCategoryRepository with full CRUD
+- ✅ Hierarchy depth validation in repository (max 2 levels)
+- ✅ Firestore path: users/{userId}/activity_categories (subcollection)
+- ✅ Firestore Security Rules updated and deployed
+- ✅ 27 new unit tests (model + repository)
+- ✅ Total test count: 187 → 214 tests (+27)
 
 ### v2.4.0 - US-024 + US-025 Persons List & Person Detail (February 23, 2026)
 - ✅ PersonsListScreen with alphabetical list, search/filter and empty state

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -731,13 +731,14 @@ If you already created a GitHub issue for US-005, you can:
 
 **Story Points:** 13  
 **Priority:** P1 (post-MVP)
+**Status:** ✅ COMPLETED (February 23, 2026)
 
 **Acceptance Criteria:**
-- [ ] ActivityCategory model created (max 3 levels deep)
-- [ ] parentCategoryId: String? for hierarchy support
-- [ ] isGlobal: bool field
-- [ ] Security Rules updated for activity_categories collection
-- [ ] Unit tests written
+- [x] ActivityCategory model created (max 2 levels deep)
+- [x] parentCategoryId: String? for hierarchy support
+- [x] isGlobal: bool field
+- [x] Security Rules updated for activity_categories collection
+- [x] Unit tests written
 
 ### US-020: Global Activity Library
 
@@ -754,6 +755,8 @@ If you already created a GitHub issue for US-005, you can:
 - [ ] Global activities read-only for users (isGlobal: true)
 - [ ] Private activities manageable by user
 - [ ] Security Rules enforce read-only on global data
+- [ ] On first login: batch-copy all global categories to user's subcollection (users/{userId}/activity_categories)
+- [ ] After onboarding: user sees only their own private categories
 
 ### US-021: Meetings List Screen
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -226,37 +226,25 @@ Zaktualizuj też ostatnią linię `architecture.md`:
 
 ### M2 — Activity Category Hierarchy
 
-Activity categories support up to 3 levels of nesting via `parentCategoryId`:
-
+Activity categories support up to **2 levels** of nesting via `parentCategoryId`.
+Users start with a copy of global categories (seeded during onboarding — US-020).
+After onboarding, users see and manage only their own private categories.
 ```
-Sport (level 1, isGlobal: true)
-├── Kayaking (level 2, isGlobal: true)
-└── Tennis (level 2, isGlobal: true)
+Sport (level 1, isGlobal: false, userId: uid)
+└── Tennis (level 2, isGlobal: false, userId: uid)
 
-Food & Drinks (level 1, isGlobal: true)
-├── Restaurant (level 2, isGlobal: true)
-└── Home Cooking (level 2, isGlobal: true)
-
-My Custom Category (level 1, isGlobal: false, userId: uid)
-└── My Subcategory (level 2, isGlobal: false, userId: uid)
+Food & Drinks (level 1, isGlobal: false, userId: uid)
+└── Restaurant (level 2, isGlobal: false, userId: uid)
 ```
 
-**Icon System:** Icons stored as string identifiers (e.g. `"sports_tennis"`, `"kayaking"`) referencing Material Icons. Predefined set of ~50 icons. No image uploads — identifier resolved to widget at render time.
+**Firestore path:** `users/{userId}/activity_categories` (subcollection)
+Depth validation enforced in `ActivityCategoryRepository._validateDepth()`.
+
+**Icon System:** Icons stored as string identifiers (e.g. `"sports_tennis"`, `"restaurant"`) referencing Material Icons. Predefined set of ~50 icons. No image uploads — identifier resolved to widget at render time.
 
 **Statistics implication:** Filtering by parent category includes all descendants. Query logic: load full category tree client-side, resolve descendant IDs, filter meetings.
 
-**AddMeetingProvider dual mode (US-023):**
-- Accepts optional `initialMeeting` parameter
-- Edit mode: pre-fills form, calls `updateMeeting` instead of `saveMeeting`
-- `initializeEditData()` loads full Person and Activity objects for pre-fill
-- `savedMeeting` getter returns updated Meeting after successful save
-
-**MeetingDetailScreen navigation pattern:**
-- Receives Meeting object via constructor (no additional Firestore fetch)
-- Edit: pushes AddMeetingScreen, awaits updated Meeting, re-initializes provider
-- Delete: calls deleteMeeting, pops with 'deleted' string result
-- Back: pops with current _meeting state so MeetingsListScreen stream handles refresh
-
+**Onboarding copy logic:** On first login, all global categories are batch-copied to user's subcollection (US-020). Global categories are invisible to the user after onboarding.
 ---
 
 ### M3 — Statistics Architecture
@@ -372,7 +360,7 @@ graph LR
         B[meetings/]
         C[persons/]
         D[activities/]
-        E[activity_categories/]
+        E[activity_categories/] → E[users/{userId}/activity_categories/]
         F[invitation_codes/ - M5]
     end
     
@@ -386,7 +374,7 @@ graph LR
     B1 -.->|references| C1
     B1 -.->|references| D1
     D1 -.->|references| E1
-    E1 -.->|"self-reference (max 3 levels)"| E1
+    E1 -.->|"self-reference (max 2 levels)"| E1
 ```
 
 **Global vs Private data pattern:**
@@ -537,4 +525,5 @@ graph TB
 ---
 
 **End of Document - Architecture Documentation**  
-**Last Updated:** February 23, 2026 (Persons List & Detail added — US-024, US-025)
+**Last Updated:** February 24, 2026 (Activity Categories model and repository — US-019)
+

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -450,7 +450,9 @@ User can ask natural language questions about their social data.
 - name: string
 - iconIdentifier: string (references predefined icon set)
 - isGlobal: bool
-- parentCategoryId: string? (optional, max 3 levels deep)
+- parentCategoryId: string? (optional, max 2 levels deep)
+- Firestore path: users/{userId}/activity_categories (subcollection per user)
+- Onboarding: global categories batch-copied to user on first login (US-020)
 - createdAt: DateTime
 ```
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -28,5 +28,14 @@ service cloud.firestore {
       allow create: if isAuthenticated() && isOwner(request.resource.data.userId);
       allow update, delete: if isAuthenticated() && isOwner(resource.data.userId);
     }
+
+    match /users/{userId}/activity_categories/{categoryId} {
+      allow read: if isAuthenticated() &&
+                    (resource.data.isGlobal == true || isOwner(resource.data.userId));
+      allow create, update: if isAuthenticated() &&
+                               request.resource.data.isGlobal == false &&
+                               isOwner(request.resource.data.userId);
+      allow delete: if isAuthenticated() && isOwner(resource.data.userId);
+    }
   }
 }

--- a/lib/data/models/activity_category.dart
+++ b/lib/data/models/activity_category.dart
@@ -1,0 +1,54 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'activity_category.freezed.dart';
+part 'activity_category.g.dart';
+
+/// Represents a category that groups activities.
+/// Categories support up to 2 levels of hierarchy via parentCategoryId.
+///
+/// Categories can be private (isGlobal: false) — created by individual users,
+/// or global (isGlobal: true) — managed separately (see US-020).
+@freezed
+class ActivityCategory with _$ActivityCategory {
+  const ActivityCategory._();
+
+  const factory ActivityCategory({
+    required String id,
+    required String userId,
+    required String name,
+    required String iconIdentifier,
+    required bool isGlobal,
+    String? parentCategoryId,
+    required DateTime createdAt,
+  }) = _ActivityCategory;
+
+  factory ActivityCategory.fromJson(Map<String, dynamic> json) =>
+      _$ActivityCategoryFromJson(json);
+
+  /// Creates an ActivityCategory from a Firestore document.
+  factory ActivityCategory.fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    return ActivityCategory(
+      id: doc.id,
+      userId: (data['userId'] ?? '') as String,
+      name: (data['name'] ?? '') as String,
+      iconIdentifier: (data['iconIdentifier'] ?? '') as String,
+      isGlobal: (data['isGlobal'] ?? false) as bool,
+      parentCategoryId: data['parentCategoryId'] as String?,
+      createdAt: (data['createdAt'] as Timestamp).toDate(),
+    );
+  }
+
+  /// Converts ActivityCategory to a map for Firestore storage.
+  Map<String, dynamic> toFirestore() {
+    return {
+      'userId': userId,
+      'name': name,
+      'iconIdentifier': iconIdentifier,
+      'isGlobal': isGlobal,
+      if (parentCategoryId != null) 'parentCategoryId': parentCategoryId,
+      'createdAt': Timestamp.fromDate(createdAt),
+    };
+  }
+}

--- a/lib/data/models/activity_category.freezed.dart
+++ b/lib/data/models/activity_category.freezed.dart
@@ -1,0 +1,296 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'activity_category.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+ActivityCategory _$ActivityCategoryFromJson(Map<String, dynamic> json) {
+  return _ActivityCategory.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ActivityCategory {
+  String get id => throw _privateConstructorUsedError;
+  String get userId => throw _privateConstructorUsedError;
+  String get name => throw _privateConstructorUsedError;
+  String get iconIdentifier => throw _privateConstructorUsedError;
+  bool get isGlobal => throw _privateConstructorUsedError;
+  String? get parentCategoryId => throw _privateConstructorUsedError;
+  DateTime get createdAt => throw _privateConstructorUsedError;
+
+  /// Serializes this ActivityCategory to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of ActivityCategory
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ActivityCategoryCopyWith<ActivityCategory> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ActivityCategoryCopyWith<$Res> {
+  factory $ActivityCategoryCopyWith(
+          ActivityCategory value, $Res Function(ActivityCategory) then) =
+      _$ActivityCategoryCopyWithImpl<$Res, ActivityCategory>;
+  @useResult
+  $Res call(
+      {String id,
+      String userId,
+      String name,
+      String iconIdentifier,
+      bool isGlobal,
+      String? parentCategoryId,
+      DateTime createdAt});
+}
+
+/// @nodoc
+class _$ActivityCategoryCopyWithImpl<$Res, $Val extends ActivityCategory>
+    implements $ActivityCategoryCopyWith<$Res> {
+  _$ActivityCategoryCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ActivityCategory
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? userId = null,
+    Object? name = null,
+    Object? iconIdentifier = null,
+    Object? isGlobal = null,
+    Object? parentCategoryId = freezed,
+    Object? createdAt = null,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      iconIdentifier: null == iconIdentifier
+          ? _value.iconIdentifier
+          : iconIdentifier // ignore: cast_nullable_to_non_nullable
+              as String,
+      isGlobal: null == isGlobal
+          ? _value.isGlobal
+          : isGlobal // ignore: cast_nullable_to_non_nullable
+              as bool,
+      parentCategoryId: freezed == parentCategoryId
+          ? _value.parentCategoryId
+          : parentCategoryId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      createdAt: null == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$ActivityCategoryImplCopyWith<$Res>
+    implements $ActivityCategoryCopyWith<$Res> {
+  factory _$$ActivityCategoryImplCopyWith(_$ActivityCategoryImpl value,
+          $Res Function(_$ActivityCategoryImpl) then) =
+      __$$ActivityCategoryImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      String userId,
+      String name,
+      String iconIdentifier,
+      bool isGlobal,
+      String? parentCategoryId,
+      DateTime createdAt});
+}
+
+/// @nodoc
+class __$$ActivityCategoryImplCopyWithImpl<$Res>
+    extends _$ActivityCategoryCopyWithImpl<$Res, _$ActivityCategoryImpl>
+    implements _$$ActivityCategoryImplCopyWith<$Res> {
+  __$$ActivityCategoryImplCopyWithImpl(_$ActivityCategoryImpl _value,
+      $Res Function(_$ActivityCategoryImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ActivityCategory
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? userId = null,
+    Object? name = null,
+    Object? iconIdentifier = null,
+    Object? isGlobal = null,
+    Object? parentCategoryId = freezed,
+    Object? createdAt = null,
+  }) {
+    return _then(_$ActivityCategoryImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      userId: null == userId
+          ? _value.userId
+          : userId // ignore: cast_nullable_to_non_nullable
+              as String,
+      name: null == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      iconIdentifier: null == iconIdentifier
+          ? _value.iconIdentifier
+          : iconIdentifier // ignore: cast_nullable_to_non_nullable
+              as String,
+      isGlobal: null == isGlobal
+          ? _value.isGlobal
+          : isGlobal // ignore: cast_nullable_to_non_nullable
+              as bool,
+      parentCategoryId: freezed == parentCategoryId
+          ? _value.parentCategoryId
+          : parentCategoryId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      createdAt: null == createdAt
+          ? _value.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ActivityCategoryImpl extends _ActivityCategory {
+  const _$ActivityCategoryImpl(
+      {required this.id,
+      required this.userId,
+      required this.name,
+      required this.iconIdentifier,
+      required this.isGlobal,
+      this.parentCategoryId,
+      required this.createdAt})
+      : super._();
+
+  factory _$ActivityCategoryImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ActivityCategoryImplFromJson(json);
+
+  @override
+  final String id;
+  @override
+  final String userId;
+  @override
+  final String name;
+  @override
+  final String iconIdentifier;
+  @override
+  final bool isGlobal;
+  @override
+  final String? parentCategoryId;
+  @override
+  final DateTime createdAt;
+
+  @override
+  String toString() {
+    return 'ActivityCategory(id: $id, userId: $userId, name: $name, iconIdentifier: $iconIdentifier, isGlobal: $isGlobal, parentCategoryId: $parentCategoryId, createdAt: $createdAt)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ActivityCategoryImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.userId, userId) || other.userId == userId) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.iconIdentifier, iconIdentifier) ||
+                other.iconIdentifier == iconIdentifier) &&
+            (identical(other.isGlobal, isGlobal) ||
+                other.isGlobal == isGlobal) &&
+            (identical(other.parentCategoryId, parentCategoryId) ||
+                other.parentCategoryId == parentCategoryId) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, id, userId, name, iconIdentifier,
+      isGlobal, parentCategoryId, createdAt);
+
+  /// Create a copy of ActivityCategory
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ActivityCategoryImplCopyWith<_$ActivityCategoryImpl> get copyWith =>
+      __$$ActivityCategoryImplCopyWithImpl<_$ActivityCategoryImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ActivityCategoryImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ActivityCategory extends ActivityCategory {
+  const factory _ActivityCategory(
+      {required final String id,
+      required final String userId,
+      required final String name,
+      required final String iconIdentifier,
+      required final bool isGlobal,
+      final String? parentCategoryId,
+      required final DateTime createdAt}) = _$ActivityCategoryImpl;
+  const _ActivityCategory._() : super._();
+
+  factory _ActivityCategory.fromJson(Map<String, dynamic> json) =
+      _$ActivityCategoryImpl.fromJson;
+
+  @override
+  String get id;
+  @override
+  String get userId;
+  @override
+  String get name;
+  @override
+  String get iconIdentifier;
+  @override
+  bool get isGlobal;
+  @override
+  String? get parentCategoryId;
+  @override
+  DateTime get createdAt;
+
+  /// Create a copy of ActivityCategory
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ActivityCategoryImplCopyWith<_$ActivityCategoryImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/data/models/activity_category.g.dart
+++ b/lib/data/models/activity_category.g.dart
@@ -1,0 +1,40 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'activity_category.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ActivityCategoryImpl _$$ActivityCategoryImplFromJson(
+        Map<String, dynamic> json) =>
+    $checkedCreate(
+      r'_$ActivityCategoryImpl',
+      json,
+      ($checkedConvert) {
+        final val = _$ActivityCategoryImpl(
+          id: $checkedConvert('id', (v) => v as String),
+          userId: $checkedConvert('userId', (v) => v as String),
+          name: $checkedConvert('name', (v) => v as String),
+          iconIdentifier: $checkedConvert('iconIdentifier', (v) => v as String),
+          isGlobal: $checkedConvert('isGlobal', (v) => v as bool),
+          parentCategoryId:
+              $checkedConvert('parentCategoryId', (v) => v as String?),
+          createdAt:
+              $checkedConvert('createdAt', (v) => DateTime.parse(v as String)),
+        );
+        return val;
+      },
+    );
+
+Map<String, dynamic> _$$ActivityCategoryImplToJson(
+        _$ActivityCategoryImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'userId': instance.userId,
+      'name': instance.name,
+      'iconIdentifier': instance.iconIdentifier,
+      'isGlobal': instance.isGlobal,
+      'parentCategoryId': instance.parentCategoryId,
+      'createdAt': instance.createdAt.toIso8601String(),
+    };

--- a/lib/data/repositories/activity_category_repository.dart
+++ b/lib/data/repositories/activity_category_repository.dart
@@ -1,0 +1,66 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../models/activity_category.dart';
+
+class ActivityCategoryRepository {
+  final FirebaseFirestore _firestore;
+
+  ActivityCategoryRepository({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+
+  CollectionReference _categoriesRef(String userId) => _firestore
+      .collection('users')
+      .doc(userId)
+      .collection('activity_categories');
+
+  // Returns a live stream of all activity categories for the given user.
+  Stream<List<ActivityCategory>> getCategories(String userId) {
+    return _categoriesRef(userId).snapshots().map(
+          (snapshot) => snapshot.docs
+              .map((doc) => ActivityCategory.fromFirestore(doc))
+              .toList(),
+        );
+  }
+
+  // Adds a new category. Throws if adding would exceed the 2-level depth limit.
+  Future<void> addCategory(ActivityCategory category) async {
+    await _validateDepth(category.userId, category);
+    await _categoriesRef(category.userId).add(category.toFirestore());
+  }
+
+  // Updates an existing category. Throws if the new parent would exceed depth 2.
+  Future<void> updateCategory(ActivityCategory category) async {
+    await _validateDepth(category.userId, category);
+    await _categoriesRef(category.userId)
+        .doc(category.id)
+        .update(category.toFirestore());
+  }
+
+  // Deletes the category document for the given user and categoryId.
+  Future<void> deleteCategory(String userId, String categoryId) async {
+    await _categoriesRef(userId).doc(categoryId).delete();
+  }
+
+  // Validates that the category does not exceed 2 levels of hierarchy.
+  // Depth 1: parentCategoryId == null (root).
+  // Depth 2: parent is a root category (parent.parentCategoryId == null).
+  // Depth 3+: not allowed — throws Exception.
+  Future<void> _validateDepth(String userId, ActivityCategory category) async {
+    if (category.parentCategoryId == null) {
+      // Root category — always valid.
+      return;
+    }
+
+    final parentDoc =
+        await _categoriesRef(userId).doc(category.parentCategoryId).get();
+    if (!parentDoc.exists) {
+      throw Exception('Parent category not found');
+    }
+
+    final parentData = parentDoc.data() as Map<String, dynamic>;
+    if (parentData['parentCategoryId'] != null) {
+      // Parent is already a subcategory — adding a child would be depth 3.
+      throw Exception('Max category depth exceeded');
+    }
+  }
+}

--- a/test/data/models/activity_category_test.dart
+++ b/test/data/models/activity_category_test.dart
@@ -1,0 +1,186 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:friendsheet/data/models/activity_category.dart';
+
+void main() {
+  group('ActivityCategory Model Tests', () {
+    // Helper: creates a valid private root category.
+    ActivityCategory createRootCategory({
+      String id = 'cat-1',
+      String userId = 'user-123',
+      String name = 'Sport',
+      String iconIdentifier = 'sports_icon',
+    }) {
+      return ActivityCategory(
+        id: id,
+        userId: userId,
+        name: name,
+        iconIdentifier: iconIdentifier,
+        isGlobal: false,
+        parentCategoryId: null,
+        createdAt: DateTime(2026, 2, 24),
+      );
+    }
+
+    // Helper: creates a valid subcategory (depth 2).
+    ActivityCategory createSubCategory({
+      String id = 'cat-2',
+      String userId = 'user-123',
+      String name = 'Running',
+      String parentCategoryId = 'cat-1',
+    }) {
+      return ActivityCategory(
+        id: id,
+        userId: userId,
+        name: name,
+        iconIdentifier: 'run_icon',
+        isGlobal: false,
+        parentCategoryId: parentCategoryId,
+        createdAt: DateTime(2026, 2, 24),
+      );
+    }
+
+    group('Field assignment', () {
+      test('root category fields are set correctly', () {
+        final category = createRootCategory();
+        expect(category.id, equals('cat-1'));
+        expect(category.userId, equals('user-123'));
+        expect(category.name, equals('Sport'));
+        expect(category.iconIdentifier, equals('sports_icon'));
+        expect(category.isGlobal, isFalse);
+        expect(category.parentCategoryId, isNull);
+      });
+
+      test('subcategory has parentCategoryId set', () {
+        final category = createSubCategory(parentCategoryId: 'cat-1');
+        expect(category.parentCategoryId, equals('cat-1'));
+      });
+    });
+
+    group('Equality (==)', () {
+      test('two categories with same data are equal', () {
+        final c1 = createRootCategory();
+        final c2 = createRootCategory();
+        expect(c1, equals(c2));
+      });
+
+      test('categories with different names are not equal', () {
+        final c1 = createRootCategory(name: 'Sport');
+        final c2 = createRootCategory(name: 'Art');
+        expect(c1, isNot(equals(c2)));
+      });
+
+      test('categories with different iconIdentifiers are not equal', () {
+        final c1 = createRootCategory(iconIdentifier: 'icon_a');
+        final c2 = createRootCategory(iconIdentifier: 'icon_b');
+        expect(c1, isNot(equals(c2)));
+      });
+    });
+
+    group('copyWith()', () {
+      test('copyWith updates name correctly', () {
+        final category = createRootCategory(name: 'Sport');
+        final updated = category.copyWith(name: 'Art');
+        expect(updated.name, equals('Art'));
+        expect(updated.id, equals(category.id));
+      });
+
+      test('copyWith assigns parentCategoryId', () {
+        final category = createRootCategory();
+        final updated = category.copyWith(parentCategoryId: 'parent-1');
+        expect(updated.parentCategoryId, equals('parent-1'));
+      });
+
+      test('copyWith updates iconIdentifier', () {
+        final category = createRootCategory(iconIdentifier: 'old_icon');
+        final updated = category.copyWith(iconIdentifier: 'new_icon');
+        expect(updated.iconIdentifier, equals('new_icon'));
+      });
+    });
+
+    group('toFirestore()', () {
+      test('includes all required fields', () {
+        final category = createRootCategory();
+        final map = category.toFirestore();
+        expect(map['userId'], equals('user-123'));
+        expect(map['name'], equals('Sport'));
+        expect(map['iconIdentifier'], equals('sports_icon'));
+        expect(map['isGlobal'], isFalse);
+        expect(map['createdAt'], isA<Timestamp>());
+      });
+
+      test('omits parentCategoryId when null', () {
+        final category = createRootCategory();
+        final map = category.toFirestore();
+        expect(map.containsKey('parentCategoryId'), isFalse);
+      });
+
+      test('includes parentCategoryId when set', () {
+        final category = createSubCategory(parentCategoryId: 'cat-1');
+        final map = category.toFirestore();
+        expect(map['parentCategoryId'], equals('cat-1'));
+      });
+    });
+
+    group('fromFirestore()', () {
+      test('deserializes all fields correctly', () async {
+        final fakeFirestore = FakeFirebaseFirestore();
+        final docRef =
+            await fakeFirestore.collection('activity_categories').add({
+          'userId': 'user-123',
+          'name': 'Sport',
+          'iconIdentifier': 'sports_icon',
+          'isGlobal': false,
+          'createdAt': Timestamp.fromDate(DateTime(2026, 2, 24)),
+        });
+
+        final doc = await docRef.get();
+        final category = ActivityCategory.fromFirestore(doc);
+
+        expect(category.id, equals(docRef.id));
+        expect(category.userId, equals('user-123'));
+        expect(category.name, equals('Sport'));
+        expect(category.iconIdentifier, equals('sports_icon'));
+        expect(category.isGlobal, isFalse);
+        expect(category.parentCategoryId, isNull);
+      });
+
+      test('deserializes parentCategoryId when present', () async {
+        final fakeFirestore = FakeFirebaseFirestore();
+        final docRef =
+            await fakeFirestore.collection('activity_categories').add({
+          'userId': 'user-123',
+          'name': 'Running',
+          'iconIdentifier': 'run_icon',
+          'isGlobal': false,
+          'parentCategoryId': 'cat-parent',
+          'createdAt': Timestamp.fromDate(DateTime(2026, 2, 24)),
+        });
+
+        final doc = await docRef.get();
+        final category = ActivityCategory.fromFirestore(doc);
+
+        expect(category.parentCategoryId, equals('cat-parent'));
+      });
+
+      test('uses doc.id as category id', () async {
+        final fakeFirestore = FakeFirebaseFirestore();
+        final docRef =
+            await fakeFirestore.collection('activity_categories').add({
+          'userId': 'user-123',
+          'name': 'Music',
+          'iconIdentifier': 'music_icon',
+          'isGlobal': false,
+          'createdAt': Timestamp.fromDate(DateTime(2026, 2, 24)),
+        });
+
+        final doc = await docRef.get();
+        final category = ActivityCategory.fromFirestore(doc);
+
+        expect(category.id, equals(docRef.id));
+        expect(category.id, isNotEmpty);
+      });
+    });
+  });
+}

--- a/test/data/repositories/activity_category_repository_test.dart
+++ b/test/data/repositories/activity_category_repository_test.dart
@@ -1,0 +1,195 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:friendsheet/data/models/activity_category.dart';
+import 'package:friendsheet/data/repositories/activity_category_repository.dart';
+
+void main() {
+  late FakeFirebaseFirestore fakeFirestore;
+  late ActivityCategoryRepository repository;
+
+  const userId = 'user-1';
+
+  // Helper: builds an ActivityCategory instance for testing.
+  ActivityCategory makeCategory({
+    String id = '',
+    String name = 'Sport',
+    String? parentCategoryId,
+  }) {
+    return ActivityCategory(
+      id: id,
+      userId: userId,
+      name: name,
+      iconIdentifier: 'sport_icon',
+      isGlobal: false,
+      parentCategoryId: parentCategoryId,
+      createdAt: DateTime(2026, 2, 24),
+    );
+  }
+
+  setUp(() {
+    fakeFirestore = FakeFirebaseFirestore();
+    repository = ActivityCategoryRepository(firestore: fakeFirestore);
+  });
+
+  // Returns the Firestore collection reference used by the repository.
+  CollectionReference categoriesRef() => fakeFirestore
+      .collection('users')
+      .doc(userId)
+      .collection('activity_categories');
+
+  // Seeds a root category directly in fake Firestore and returns its ID.
+  Future<String> seedRootCategory({String name = 'Root'}) async {
+    final ref = await categoriesRef().add({
+      'userId': userId,
+      'name': name,
+      'iconIdentifier': 'icon',
+      'isGlobal': false,
+      'createdAt': Timestamp.now(),
+    });
+    return ref.id;
+  }
+
+  // Seeds a subcategory (depth 2) directly in fake Firestore and returns its ID.
+  Future<String> seedSubCategory(
+    String parentId, {
+    String name = 'Sub',
+  }) async {
+    final ref = await categoriesRef().add({
+      'userId': userId,
+      'name': name,
+      'iconIdentifier': 'icon',
+      'isGlobal': false,
+      'parentCategoryId': parentId,
+      'createdAt': Timestamp.now(),
+    });
+    return ref.id;
+  }
+
+  group('ActivityCategoryRepository', () {
+    group('addCategory', () {
+      test('root category (depth 1) succeeds', () async {
+        final category = makeCategory(name: 'Sport');
+        await expectLater(repository.addCategory(category), completes);
+      });
+
+      test('subcategory (depth 2) succeeds when parent is a root', () async {
+        final parentId = await seedRootCategory();
+        final category = makeCategory(
+          name: 'Running',
+          parentCategoryId: parentId,
+        );
+        await expectLater(repository.addCategory(category), completes);
+      });
+
+      test('throws when parent is already a subcategory (depth > 2)', () async {
+        final rootId = await seedRootCategory();
+        final subId = await seedSubCategory(rootId);
+        final category = makeCategory(
+          name: 'Ultra Running',
+          parentCategoryId: subId,
+        );
+        await expectLater(
+          repository.addCategory(category),
+          throwsA(isA<Exception>()),
+        );
+      });
+
+      test('stores document in correct Firestore path', () async {
+        final category = makeCategory(name: 'Art');
+        await repository.addCategory(category);
+
+        final snapshot = await categoriesRef().get();
+        expect(snapshot.docs.length, equals(1));
+        expect(snapshot.docs.first['name'], equals('Art'));
+      });
+    });
+
+    group('updateCategory', () {
+      test('throws when new parent would exceed depth 2', () async {
+        final rootId = await seedRootCategory();
+        final subId = await seedSubCategory(rootId);
+        // Try to re-parent an existing root under a subcategory — depth 3.
+        final category = makeCategory(
+          id: rootId,
+          name: 'Renamed',
+          parentCategoryId: subId,
+        );
+        await expectLater(
+          repository.updateCategory(category),
+          throwsA(isA<Exception>()),
+        );
+      });
+
+      test('succeeds when category remains at depth 2', () async {
+        final rootId = await seedRootCategory();
+        final subId = await seedSubCategory(rootId);
+        final doc = await categoriesRef().doc(subId).get();
+        final existing = ActivityCategory.fromFirestore(doc);
+        final updated = existing.copyWith(name: 'Updated Sub');
+        await expectLater(repository.updateCategory(updated), completes);
+      });
+
+      test('persists updated name in Firestore', () async {
+        final rootId = await seedRootCategory(name: 'Old Name');
+        final doc = await categoriesRef().doc(rootId).get();
+        final existing = ActivityCategory.fromFirestore(doc);
+        await repository.updateCategory(existing.copyWith(name: 'New Name'));
+
+        final updated = await categoriesRef().doc(rootId).get();
+        expect((updated.data() as Map<String, dynamic>)['name'],
+            equals('New Name'));
+      });
+    });
+
+    group('deleteCategory', () {
+      test('deletes the category document', () async {
+        final id = await seedRootCategory(name: 'ToDelete');
+        await repository.deleteCategory(userId, id);
+
+        final doc = await categoriesRef().doc(id).get();
+        expect(doc.exists, isFalse);
+      });
+
+      test('does not affect other category documents', () async {
+        final idToKeep = await seedRootCategory(name: 'Keep');
+        final idToDelete = await seedRootCategory(name: 'Delete');
+        await repository.deleteCategory(userId, idToDelete);
+
+        final doc = await categoriesRef().doc(idToKeep).get();
+        expect(doc.exists, isTrue);
+      });
+    });
+
+    group('getCategories', () {
+      test('returns empty list when no categories exist', () async {
+        final result = await repository.getCategories(userId).first;
+        expect(result, isEmpty);
+      });
+
+      test('returns all categories for user', () async {
+        await seedRootCategory(name: 'Sport');
+        await seedRootCategory(name: 'Art');
+
+        final result = await repository.getCategories(userId).first;
+        expect(result.length, equals(2));
+      });
+
+      test('returned items are ActivityCategory instances', () async {
+        await seedRootCategory(name: 'Music');
+
+        final result = await repository.getCategories(userId).first;
+        expect(result.first, isA<ActivityCategory>());
+        expect(result.first.name, equals('Music'));
+      });
+
+      test('stream emits updated list after adding a category', () async {
+        final stream = repository.getCategories(userId);
+
+        await seedRootCategory(name: 'Dance');
+        final result = await stream.first;
+        expect(result.length, equals(1));
+      });
+    });
+  });
+}


### PR DESCRIPTION
- ActivityCategory Freezed model with 7 fields
- ActivityCategoryRepository with full CRUD
- Depth validation enforced in repository (max 2 levels)
- Firestore path: users/{userId}/activity_categories
- Firestore Security Rules updated
- 27 unit tests added (model + repository)
- Documentation updated

Closes #55