### PR TITLE
262 us 107 relationship strength indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to Friendsheet are documented here.
 
 ---
 
+### v4.5.6 — US-107: Relationship Strength Indicator (April 1, 2026)
+- ✅ `lib/data/services/relationship_score_service.dart` (NEW) — `RelationshipScore` data class + `RelationshipScoreService.computeScore(userId, personId)`; 4-factor algorithm: frequency 35% (cap 48/2y), recency 30% (all-time last meeting, 0 at 360d), category variety 20% (cap 10/2y), weight variety 15% (cap 3/2y); labels: Very close / Strong / Good / Fading / Distant; reads from `LocalCacheService` only — no Firestore
+- ✅ `lib/presentation/persons/relationship_strength_widget.dart` (NEW) — `StatelessWidget`; colored `LinearProgressIndicator` (green ≥80, lightGreen ≥60, amber ≥40, orange ≥20, red <20) + score/100 + label
+- ✅ `lib/presentation/persons/person_detail_provider.dart` (MODIFIED) — optional `RelationshipScoreService` constructor param; `_score: RelationshipScore?` field + `get score` getter; `initialize()` calls `computeScore` after meeting count fetch
+- ✅ `lib/presentation/persons/person_detail_screen.dart` (MODIFIED) — `RelationshipStrengthWidget` added as first `ListView` child when `provider.score != null`
+- ✅ `lib/data/services/context_builder_service.dart` (MODIFIED) — optional `RelationshipScoreService` constructor param; `serializeToPromptWithScores(BuddyContext, userId)` async method appends `### Relationship Scores` section with per-person partial scores (freq/35, recency/30, variety/20, weight_variety/15)
+- ✅ `lib/data/services/open_ai_service.dart` (MODIFIED) — `_systemPrompt` extended with Relationship Scores interpretation instructions, partial score format example, and meeting suggestion guidance (familiar top activity + fresh rare/new activity)
+- ✅ `lib/presentation/ai_chat/ai_chat_provider.dart` (MODIFIED) — `sendMessage()` replaced with disambiguation-aware flow: `_findMatchingPersons()` (substring match on firstName/lastName/nicknames via `LocalCacheService`); 0 matches → exact full-name fallback; 1 match → pseudonymize + send; 2+ matches → disambiguation prompt + action buttons showing score; `_sendToBuddy()` extracted helper; `_showPersonDisambiguation()` streams disambiguation message + buttons; `handleAction` handles `disambiguate_person:personId`
+- ✅ `test/data/services/relationship_score_service_test.dart` (NEW) — 5 unit tests: no meetings, happy path (full score+fields), all-time recency, max score 100, Fading boundary; uses Hive with temp directory
+- ✅ `test/presentation/persons/relationship_strength_widget_test.dart` (NEW) — 4 widget tests: renders score/label/title/bar, progress bar value, green color ≥80, red color <20
+- ✅ `test/data/services/context_builder_service_test.dart` (MODIFIED) — 2 new tests: `serializeToPromptWithScores` appends Scores section, returns base only when no persons
+- ✅ `test/presentation/providers/ai_chat_provider_test.dart` (MODIFIED) — 2 new tests: 2-person ambiguity → disambiguation message+buttons (no AI call), disambiguate_person action → AI called with pseudonymized text
+- ✅ 895 Flutter tests passing (+13 new tests)
+
+---
+
 ### v4.5.5 — US-105 + US-118: Meeting Frequency Context & LTNS Exclusion Filter (March 31, 2026)
 - ✅ `lib/data/models/buddy_context.dart` (MODIFIED) — `avgDaysBetweenMeetings: int?` and `daysSinceLastMeeting: int?` added to `PersonContextEntry`; both nullable (null when < 2 meetings in window for avg, or no last meeting date for days-since)
 - ✅ `lib/data/services/context_builder_service.dart` (MODIFIED) — `_buildPersonEntries()` computes `avgDaysBetweenMeetings` (sort meetings by date, compute consecutive gaps, average) and `daysSinceLastMeeting` (derived from `lastMeetingDate`); `serializeToPrompt()` emits both fields in Friend Summaries section

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 **M6 — Custom Dashboard:** Configurable home screen with drag-and-drop metric widgets.
 
-**M7 — AI Assistant:** Buddy — an AI chat assistant powered by OpenAI (BYOK). US-087 delivered the full chat screen with streaming responses, pseudonym back-translation, and write isolation via `BuddyWriteService`. US-101 added the proactive HomeScreen widget (floating Buddy icon with contextual CTAs). US-103 added birthday data to Person. US-104 delivered birthday reminders: Buddy detects upcoming birthdays, generates Dart-computed friendship stats, and streams a personalized AI birthday wish; "Save Your Memories" shows top-3 meetings without notes as in-chat action buttons. US-102 added proactive LTNS insights: "Long time no see" button for friends absent 90+ days; greeting/lapsedFriendsList/lapsedFriendDetail chat modes; Side Menu "Buddy" tile navigating to a dedicated sub-screen; AIChatScreen AppBar uses Pacifico font. US-109 delivered the full-dataset local Hive cache (`LocalCacheService`): fire-and-forget sync on app start, write-through after every repository write, 8 typed read methods — all one-shot Firestore reads now cache-first. US-105 added meeting frequency context: `PersonContextEntry` carries `avgDaysBetweenMeetings` and `daysSinceLastMeeting`; system prompt guides Buddy to suggest overdue friends. US-118 added LTNS Exclusion Filter: `LtnsExclusionService` + `LtnsFilterScreen` allow opt-out of specific friends from LTNS reminders; action buttons show full name and meeting frequency. Remaining US: widget auto-refresh (US-112), language selection (US-113).
+**M7 — AI Assistant:** Buddy — an AI chat assistant powered by OpenAI (BYOK). US-087 delivered the full chat screen with streaming responses, pseudonym back-translation, and write isolation via `BuddyWriteService`. US-101 added the proactive HomeScreen widget (floating Buddy icon with contextual CTAs). US-103 added birthday data to Person. US-104 delivered birthday reminders: Buddy detects upcoming birthdays, generates Dart-computed friendship stats, and streams a personalized AI birthday wish; "Save Your Memories" shows top-3 meetings without notes as in-chat action buttons. US-102 added proactive LTNS insights: "Long time no see" button for friends absent 90+ days; greeting/lapsedFriendsList/lapsedFriendDetail chat modes; Side Menu "Buddy" tile navigating to a dedicated sub-screen; AIChatScreen AppBar uses Pacifico font. US-109 delivered the full-dataset local Hive cache (`LocalCacheService`): fire-and-forget sync on app start, write-through after every repository write, 8 typed read methods — all one-shot Firestore reads now cache-first. US-105 added meeting frequency context: `PersonContextEntry` carries `avgDaysBetweenMeetings` and `daysSinceLastMeeting`; system prompt guides Buddy to suggest overdue friends. US-118 added LTNS Exclusion Filter: `LtnsExclusionService` + `LtnsFilterScreen` allow opt-out of specific friends from LTNS reminders; action buttons show full name and meeting frequency. US-107 added Relationship Strength Indicator: `RelationshipScoreService` computes a 0–100 score (frequency/recency/variety/weight variety) from the Hive cache; `RelationshipStrengthWidget` shows a colored progress bar on `PersonDetailScreen`; `serializeToPromptWithScores` appends per-person partial scores so Buddy can explain them; smart person name disambiguation — when a user types a real name Buddy resolves it via substring match and shows disambiguation buttons with scores if multiple persons match. Remaining US: widget auto-refresh (US-112), language selection (US-113).
 
 ---
 
@@ -108,7 +108,7 @@ flutter format --set-exit-if-changed .
 
 **Current Test Status:**
 ```
-✅ All tests passing (881)
+✅ All tests passing (895)
 ✅ Code formatted correctly
 ✅ Firebase connected successfully
 ✅ CI/CD pipeline operational
@@ -174,13 +174,12 @@ Project Link: [https://github.com/aleksanderginalski/Friendsheet-App](https://gi
 
 Full version history is available in [CHANGELOG.md](CHANGELOG.md).
 
-### Latest: v4.5.5 — US-105 + US-118: Meeting Frequency Context & LTNS Exclusion Filter (March 31, 2026)
-- ✅ `PersonContextEntry` extended with `avgDaysBetweenMeetings` and `daysSinceLastMeeting`; both fields serialized into the AI prompt so Buddy can compare meeting cadence vs elapsed time and suggest overdue friends
-- ✅ `OpenAIService` system prompt extended with meeting suggestion guidance ("Who should I meet next?" queries now reference specific frequency patterns)
-- ✅ `LtnsExclusionService` (NEW): SharedPreferences-backed opt-out filter; users can exclude specific friends from LTNS reminders via the new LTNS Filters screen
-- ✅ `LtnsFilterScreen` (NEW): `StatefulWidget` with `SwitchListTile` per person, Polish-aware sorting, search bar, and immediate persistence
-- ✅ LTNS action buttons now show full name + frequency suffix ("· prev. every X days") when cadence data is available
-- ✅ 20 new unit tests (881 total)
+### Latest: v4.5.6 — US-107: Relationship Strength Indicator (April 1, 2026)
+- ✅ `RelationshipScoreService` (NEW): local 0–100 scoring — frequency 35%, recency 30%, category variety 20%, weight variety 15%; reads from Hive cache only
+- ✅ `RelationshipStrengthWidget` (NEW): colored progress bar with score/100 and label shown on `PersonDetailScreen`
+- ✅ `serializeToPromptWithScores`: async variant appending `### Relationship Scores` section so Buddy can explain scores
+- ✅ Smart person name disambiguation in Buddy chat: substring match on firstName/lastName/nicknames; 1 match → auto-pseudonymize; 2+ matches → disambiguation prompt with score buttons
+- ✅ 13 new unit/widget tests (895 total)
 
 See [CHANGELOG.md](CHANGELOG.md) for all previous versions.
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -4414,25 +4414,43 @@ Current UI is in English. This US extracts all UI strings into ARB files and add
 **Story Points:** 13
 **Priority:** P2
 **Labels:** `ai`, `analytics`, `persons`
-**Status:** 📋 Planned
+**Status:** 🔄 In Progress
 
 **Acceptance Criteria:**
 - [ ] Relationship strength score calculated per person (0–100)
-- [ ] Score factors: meeting frequency, recency, variety of activities, meeting weight
-- [ ] Score displayed on `PersonDetailScreen` as a visual indicator
+- [ ] Score factors: meeting frequency (2y), recency, category variety (2y), weight variety (2y)
+- [ ] Score displayed on `PersonDetailScreen` as a visual indicator (progress bar + label)
 - [ ] Buddy can explain the score on request: "Why is my score with Tomek 62?"
-- [ ] Score updated after each new meeting or note change
-- [ ] Score calculation is local (no API call required) — `ContextBuilderService` computes it
+- [ ] Score recomputed on every `PersonDetailScreen` open (cache-based, no loading flicker)
+- [ ] Score calculation is local (no API call required) — `RelationshipScoreService` reads from `LocalCacheService`
+
+**Scoring Algorithm (finalised in planning):**
+
+| Factor | Window | Cap | Weight |
+|---|---|---|---|
+| Frequency | meetings with person in last 730 days | ≥ 48 (2/month) | 35% |
+| Recency | days since last meeting (all time) | ≤ 14 days = 100%, 0 at 360 days | 30% |
+| Category variety | distinct category IDs in meetings (730 days) | ≥ 10 categories | 20% |
+| Weight variety | distinct weight values used in meetings (730 days) from {1,2,3,5,8,13,21} | ≥ 3 distinct values | 15% |
+
+Formulas:
+- `frequency = min(count2y, 48) / 48`
+- `recency = max(0.0, (360 - daysSince) / 360)` — effectively 1.0 when daysSince ≤ 14
+- `variety = min(distinctCategories2y, 10) / 10`
+- `weightVariety = min(distinctWeights2y, 3) / 3`
+- `score = (frequency×35 + recency×30 + variety×20 + weightVariety×15).round()`
+
+Score labels: 80–100 → "Very close" · 60–79 → "Strong" · 40–59 → "Good" · 20–39 → "Fading" · 0–19 → "Distant"
 
 **Tasks:**
-- [ ] **TASK-107.1:** Design scoring algorithm (frequency, recency, variety, weight) — 2h
-- [ ] **TASK-107.2:** Implement `RelationshipScoreService`; reads all meetings and persons from `LocalCacheService` — no direct Firestore calls — 3h
-- [ ] **TASK-107.3:** Add score indicator widget to `PersonDetailScreen` — 2h
-- [ ] **TASK-107.4:** Wire score explanation to Buddy (prompt template) — 1h
+- [x] **TASK-107.1:** Design scoring algorithm (finalised in planning session) — 2h
+- [ ] **TASK-107.2:** Implement `RelationshipScoreService` in `lib/data/services/`; reads from `LocalCacheService` only — 3h
+- [ ] **TASK-107.3:** Add `RelationshipStrengthWidget` to `lib/presentation/persons/`; display in `PersonDetailScreen._PersonDetailBody` — 2h
+- [ ] **TASK-107.4:** Inject score breakdown into `ContextBuilderService.serializeToPrompt` per person so Buddy can explain it — 1h
 - [ ] **TASK-107.5:** Write unit tests for scoring algorithm — 3h
 - [ ] **TASK-107.6:** Write widget tests for score indicator — 2h
 
-**Dependencies:** US-086, US-087
+**Dependencies:** US-086, US-087, US-109
 **Blocks:** None
 
 ---

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -4414,15 +4414,15 @@ Current UI is in English. This US extracts all UI strings into ARB files and add
 **Story Points:** 13
 **Priority:** P2
 **Labels:** `ai`, `analytics`, `persons`
-**Status:** 🔄 In Progress
+**Status:** ✅ Completed
 
 **Acceptance Criteria:**
-- [ ] Relationship strength score calculated per person (0–100)
-- [ ] Score factors: meeting frequency (2y), recency, category variety (2y), weight variety (2y)
-- [ ] Score displayed on `PersonDetailScreen` as a visual indicator (progress bar + label)
-- [ ] Buddy can explain the score on request: "Why is my score with Tomek 62?"
-- [ ] Score recomputed on every `PersonDetailScreen` open (cache-based, no loading flicker)
-- [ ] Score calculation is local (no API call required) — `RelationshipScoreService` reads from `LocalCacheService`
+- [x] Relationship strength score calculated per person (0–100)
+- [x] Score factors: meeting frequency (2y), recency, category variety (2y), weight variety (2y)
+- [x] Score displayed on `PersonDetailScreen` as a visual indicator (progress bar + label)
+- [x] Buddy can explain the score on request: "Why is my score with Tomek 62?"
+- [x] Score recomputed on every `PersonDetailScreen` open (cache-based, no loading flicker)
+- [x] Score calculation is local (no API call required) — `RelationshipScoreService` reads from `LocalCacheService`
 
 **Scoring Algorithm (finalised in planning):**
 
@@ -4444,11 +4444,11 @@ Score labels: 80–100 → "Very close" · 60–79 → "Strong" · 40–59 → "
 
 **Tasks:**
 - [x] **TASK-107.1:** Design scoring algorithm (finalised in planning session) — 2h
-- [ ] **TASK-107.2:** Implement `RelationshipScoreService` in `lib/data/services/`; reads from `LocalCacheService` only — 3h
-- [ ] **TASK-107.3:** Add `RelationshipStrengthWidget` to `lib/presentation/persons/`; display in `PersonDetailScreen._PersonDetailBody` — 2h
-- [ ] **TASK-107.4:** Inject score breakdown into `ContextBuilderService.serializeToPrompt` per person so Buddy can explain it — 1h
-- [ ] **TASK-107.5:** Write unit tests for scoring algorithm — 3h
-- [ ] **TASK-107.6:** Write widget tests for score indicator — 2h
+- [x] **TASK-107.2:** Implement `RelationshipScoreService` in `lib/data/services/`; reads from `LocalCacheService` only — 3h
+- [x] **TASK-107.3:** Add `RelationshipStrengthWidget` to `lib/presentation/persons/`; display in `PersonDetailScreen._PersonDetailBody` — 2h
+- [x] **TASK-107.4:** Inject score breakdown into `ContextBuilderService.serializeToPromptWithScores` per person so Buddy can explain it — 1h
+- [x] **TASK-107.5:** Write unit tests for scoring algorithm — 3h
+- [x] **TASK-107.6:** Write widget tests for score indicator — 2h
 
 **Dependencies:** US-086, US-087, US-109
 **Blocks:** None

--- a/docs/TEST_CASES.md
+++ b/docs/TEST_CASES.md
@@ -1761,3 +1761,39 @@ Run after every release or hotfix:
 | UT-105-010 | greeting_ltns sub-flow label includes fullName and freq suffix | label contains 'Jan Nowak'; 'prev. every 20 days' |
 | UT-105-011 | sendMessage clears pendingActions | pendingActions null after sendMessage |
 
+
+
+## US-107 — Relationship Strength Indicator
+
+### Automated tests — `test/data/services/relationship_score_service_test.dart` (NEW)
+
+| ID | Test name | Expected |
+|----|-----------|---------|
+| UT-107-001 | returns Distant/0 with -1 daysSinceLast when no meetings | score=0, label=Distant, daysSinceLast=-1, all counters=0 |
+| UT-107-002 | computes correct score and fields for meetings within 2y window | score=55, label=Good, meetingsIn2y=12, daysSinceLast=0, cats=3, weights=2 |
+| UT-107-003 | uses all-time last meeting for recency — not limited to 2y window | daysSinceLast=800 (not -1), meetingsIn2y=0 |
+| UT-107-004 | returns Very close / 100 when all factors hit their caps | score=100, label=Very close |
+| UT-107-005 | score label Fading for score 20–39 | score in [20,39], label=Fading |
+
+### Automated tests — `test/presentation/persons/relationship_strength_widget_test.dart` (NEW)
+
+| ID | Test name | Expected |
+|----|-----------|---------|
+| UT-107-006 | renders score, label, title and progress bar | finds '55/100', 'Good', 'Relationship Strength', LinearProgressIndicator |
+| UT-107-007 | progress bar value equals score/100 | indicator.value ≈ 0.75 |
+| UT-107-008 | bar color is green for score >= 80 | indicator.color == Colors.green |
+| UT-107-009 | bar color is red for score < 20 | indicator.color == Colors.red |
+
+### Automated tests — `test/data/services/context_builder_service_test.dart` (additions)
+
+| ID | Test name | Expected |
+|----|-----------|---------|
+| UT-107-010 | serializeToPromptWithScores appends Relationship Scores section | output contains '### Relationship Scores'; 'Friend_A: score 55/100 (Good)' |
+| UT-107-011 | serializeToPromptWithScores returns base prompt only when no persons | output does not contain '### Relationship Scores'; computeScore never called |
+
+### Automated tests — `test/presentation/providers/ai_chat_provider_test.dart` (additions)
+
+| ID | Test name | Expected |
+|----|-----------|---------|
+| UT-107-012 | 2 persons match → disambiguation message + 2 action buttons, no AI call | messages[2] contains "I'm not sure who you mean"; pendingActions length=2; OpenAI not called |
+| UT-107-013 | disambiguate_person action sends pseudonymized text to AI | last message is assistant; content contains real name (pseudonym translated back) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -584,7 +584,7 @@ AIChatScreen
 - `birthday_format_helpers.dart` ✅ — pure functions: `formatBirthdayStats()`, `buildBirthdayListGreeting()`, `birthdayActionLabel()` (`lib/presentation/ai_chat/birthday_format_helpers.dart`)
 - `LocalCacheService` ✅ — Hive-based full dataset cache (meetings, persons, activity_categories); exposes typed read methods for tool calling; write-through on every repository write (US-109) (`lib/data/services/local_cache_service.dart`)
 - `ConnectivityService` 📋 — singleton with `ValueNotifier<ConnectivityStatus>`; drives offline banner and graceful degradation (US-111)
-- `RelationshipScoreService` 📋 — local scoring algorithm, no API calls (US-107)
+- `RelationshipScoreService` ✅ — local 0–100 scoring algorithm (frequency 35%, recency 30%, category variety 20%, weight variety 15%); reads exclusively from `LocalCacheService`, no API calls (US-107) (`lib/data/services/relationship_score_service.dart`)
 - `AIKeyRepository` ✅ — Flutter Secure Storage wrapper for OpenAI key (`lib/data/repositories/ai_key_repository.dart`)
 
 **New packages (US-087):**
@@ -689,6 +689,18 @@ getMeetingNotes(String meetingId) → List<String>
 - `CatchUpTopicsProvider` — ChangeNotifier; load, add, archive, delete
 
 **UI placement:** `PersonDetailScreen` — new `CatchUpListSection` below "Meetings together", above "Nicknames".
+
+---
+
+### RelationshipStrengthWidget (US-107)
+
+`lib/presentation/persons/relationship_strength_widget.dart` — `StatelessWidget`; displays relationship score as a colored `LinearProgressIndicator` with score/100 and label.
+
+Color scale: green (≥80), lightGreen (≥60), amber (≥40), orange (≥20), red (<20).
+
+Score computed by `RelationshipScoreService.computeScore()` in `PersonDetailProvider.initialize()`; injected via `RelationshipScoreService` constructor param.
+
+**UI placement:** `PersonDetailScreen` — first item in the `ListView` body, above meeting list.
 
 ---
 

--- a/lib/data/services/context_builder_service.dart
+++ b/lib/data/services/context_builder_service.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:intl/intl.dart';
 
 import '../models/buddy_context.dart';
@@ -5,6 +7,7 @@ import '../models/meeting.dart';
 import '../repositories/activity_category_repository.dart';
 import '../repositories/meeting_repository.dart';
 import '../repositories/person_repository.dart';
+import 'relationship_score_service.dart';
 
 /// Converts the user's social data from Firestore into an anonymized AI
 /// prompt context. Real participant names are replaced with pseudonyms
@@ -17,14 +20,18 @@ class ContextBuilderService {
     MeetingRepository? meetingRepository,
     PersonRepository? personRepository,
     ActivityCategoryRepository? activityCategoryRepository,
+    RelationshipScoreService? relationshipScoreService,
   })  : _meetingRepository = meetingRepository ?? MeetingRepository(),
         _personRepository = personRepository ?? PersonRepository(),
         _activityCategoryRepository =
-            activityCategoryRepository ?? ActivityCategoryRepository();
+            activityCategoryRepository ?? ActivityCategoryRepository(),
+        _relationshipScoreService =
+            relationshipScoreService ?? RelationshipScoreService();
 
   final MeetingRepository _meetingRepository;
   final PersonRepository _personRepository;
   final ActivityCategoryRepository _activityCategoryRepository;
+  final RelationshipScoreService _relationshipScoreService;
 
   static final _monthFormat = DateFormat('MMMM yyyy');
   static final _dateFormat = DateFormat('dd MMM yyyy');
@@ -268,6 +275,50 @@ class ContextBuilderService {
     }
 
     return buffer.toString().trimRight();
+  }
+
+  /// Async variant of [serializeToPrompt] that appends a Relationship Scores
+  /// section so Buddy can explain individual scores on request.
+  ///
+  /// Uses [_relationshipScoreService] to compute a score per person in [context].
+  /// Falls back to plain [serializeToPrompt] output if no persons are present.
+  Future<String> serializeToPromptWithScores(
+    BuddyContext context,
+    String userId, {
+    bool includeNotes = false,
+  }) async {
+    final base = serializeToPrompt(context, includeNotes: includeNotes);
+    if (context.persons.isEmpty) return base;
+
+    // Build inverse map: pseudonym → personId for score lookup.
+    final pseudonymToPersonId = {
+      for (final e in context.personIdToPseudonym.entries) e.value: e.key,
+    };
+
+    final scoreBuffer = StringBuffer('\n\n### Relationship Scores');
+    for (final p in context.persons) {
+      final personId = pseudonymToPersonId[p.pseudonym];
+      if (personId == null) continue;
+      final s = await _relationshipScoreService.computeScore(userId, personId);
+
+      // Compute partial scores matching the four factors.
+      final freqPts = (min(s.meetingsIn2y, 48) / 48 * 35).round();
+      final recencyPts = s.daysSinceLast == -1
+          ? 0
+          : (max(0.0, (360 - s.daysSinceLast) / 360) * 30).round();
+      final varietyPts = (min(s.distinctCategories2y, 10) / 10 * 20).round();
+      final weightPts = (min(s.distinctWeights2y, 3) / 3 * 15).round();
+
+      scoreBuffer.write(
+        '\n- ${p.pseudonym}: score ${s.score}/100 (${s.label})'
+        ' — freq: $freqPts/35 (${s.meetingsIn2y} meetings/2y)'
+        ', recency: $recencyPts/30 (${s.daysSinceLast == -1 ? 'never met' : '${s.daysSinceLast} days ago'})'
+        ', variety: $varietyPts/20 (${s.distinctCategories2y} categories)'
+        ', weight_variety: $weightPts/15 (${s.distinctWeights2y} weight types)',
+      );
+    }
+
+    return base + scoreBuffer.toString();
   }
 
   /// Returns the meeting with [meetingId], or null if not found.

--- a/lib/data/services/open_ai_service.dart
+++ b/lib/data/services/open_ai_service.dart
@@ -29,6 +29,34 @@ When a user asks who they should meet next, or who they haven't seen in a while:
   e.g. "You typically meet Friend_A every 30 days, but it's been 95 days — maybe reach out?"
 - Always use pseudonyms in your reasoning; the app will translate them back to real names
 - If no frequency data is available, fall back to ranking friends by days since last meeting
+
+Relationship Strength Scores (section "### Relationship Scores" in context):
+- Each friend has a score 0–100 from four factors, each shown as partial/max:
+  - freq X/35: meeting frequency in last 2 years (full at 48 meetings)
+  - recency X/30: days since last meeting (full at ≤14 days, zero at 360 days)
+  - variety X/20: distinct activity category types in last 2 years (full at 10)
+  - weight_variety X/15: distinct meeting weight values in last 2 years (full at 3)
+- Labels: 80–100 = "Very close", 60–79 = "Strong", 40–59 = "Good", 20–39 = "Fading", 0–19 = "Distant"
+- The Friend Summaries section shows meetings from the last 12 months only.
+  The Relationship Scores section covers the last 2 years — a friend may appear with few
+  recent meetings in Friend Summaries but still have a meaningful score from 1–2 years ago.
+
+When a user asks about their score with a specific friend:
+- Refer ONLY to that friend's pseudonym. Do NOT mention other friends by name.
+- Show each factor as "X/max pts" and explain briefly what it means.
+- Example format:
+  "Your score with Friend_X is 57/100 (Good):
+   - Frequency: 9/35 pts — 16 meetings in 2 years
+   - Recency: 11/30 pts — last met 126 days ago
+   - Variety: 20/20 pts — 13 activity types
+   - Weight variety: 15/15 pts — 3 weight types"
+- After the breakdown, suggest TWO meeting ideas:
+  1. A familiar activity: pick the category that appears MOST often in this friend's top activities
+     (from Friend Summaries). Frame it as "something you already enjoy together."
+  2. A fresh activity: pick a category that appears in OTHER friends' top activities but NOT
+     in this friend's top activities, OR one that is rare across all meetings (appeared ≤2 times).
+     Frame it as "something new to try together."
+- Always use pseudonyms in your response; the app will translate them to real names.
 ''';
 
 /// Wraps the OpenAI Responses API and exposes a streaming interface.

--- a/lib/data/services/relationship_score_service.dart
+++ b/lib/data/services/relationship_score_service.dart
@@ -39,9 +39,8 @@ class RelationshipScoreService {
     String personId,
   ) async {
     final allMeetings = await LocalCacheService().getAllMeetings(userId);
-    final personMeetings = allMeetings
-        .where((m) => m.participantIds.contains(personId))
-        .toList();
+    final personMeetings =
+        allMeetings.where((m) => m.participantIds.contains(personId)).toList();
 
     if (personMeetings.isEmpty) {
       return const RelationshipScore(
@@ -86,8 +85,7 @@ class RelationshipScoreService {
     final weightVar = min(weightValues2y.length, 3) / 3;
 
     final score =
-        (frequency * 35 + recency * 30 + variety * 20 + weightVar * 15)
-            .round();
+        (frequency * 35 + recency * 30 + variety * 20 + weightVar * 15).round();
 
     return RelationshipScore(
       score: score,

--- a/lib/data/services/relationship_score_service.dart
+++ b/lib/data/services/relationship_score_service.dart
@@ -1,0 +1,109 @@
+import 'dart:math';
+
+import 'local_cache_service.dart';
+
+// Breakdown of a single person's relationship strength score (0–100).
+// All fields are final and the class is const-constructible for easy testing.
+class RelationshipScore {
+  final int score;
+  final String label;
+  final int meetingsIn2y;
+  final int daysSinceLast; // -1 when no meetings exist
+  final int distinctCategories2y;
+  final int distinctWeights2y;
+
+  const RelationshipScore({
+    required this.score,
+    required this.label,
+    required this.meetingsIn2y,
+    required this.daysSinceLast,
+    required this.distinctCategories2y,
+    required this.distinctWeights2y,
+  });
+}
+
+// Computes a 0–100 relationship strength score per person from the Hive cache.
+// No Firestore reads — reads exclusively via LocalCacheService.
+//
+// Factors and weights:
+//   Frequency    35% — meetings in last 730 days, cap at 48 (2/month)
+//   Recency      30% — days since last meeting (all time), 0 at 360 days
+//   Variety      20% — distinct category IDs in last 730 days, cap at 10
+//   WeightVar    15% — distinct weight values used in last 730 days, cap at 3
+class RelationshipScoreService {
+  // Computes the relationship strength score for [personId] using cached data.
+  // Frequency, variety, and weight variety use a 730-day window.
+  // Recency uses the most recent meeting across all time (no window).
+  Future<RelationshipScore> computeScore(
+    String userId,
+    String personId,
+  ) async {
+    final allMeetings = await LocalCacheService().getAllMeetings(userId);
+    final personMeetings = allMeetings
+        .where((m) => m.participantIds.contains(personId))
+        .toList();
+
+    if (personMeetings.isEmpty) {
+      return const RelationshipScore(
+        score: 0,
+        label: 'Distant',
+        meetingsIn2y: 0,
+        daysSinceLast: -1,
+        distinctCategories2y: 0,
+        distinctWeights2y: 0,
+      );
+    }
+
+    final now = DateTime.now();
+    final cutoff2y = now.subtract(const Duration(days: 730));
+
+    // Recency: use the most recent meeting regardless of time window.
+    final lastMeeting = personMeetings.reduce(
+      (a, b) => a.date.isAfter(b.date) ? a : b,
+    );
+    final daysSinceLast = now.difference(lastMeeting.date).inDays;
+
+    // 2-year window subset.
+    final meetings2y =
+        personMeetings.where((m) => m.date.isAfter(cutoff2y)).toList();
+    final count2y = meetings2y.length;
+
+    // Distinct category IDs across 2-year meetings.
+    final categoryIds2y = <String>{};
+    for (final m in meetings2y) {
+      categoryIds2y.addAll(m.categoryIds);
+    }
+
+    // Distinct weight values across 2-year meetings.
+    final weightValues2y = <int>{};
+    for (final m in meetings2y) {
+      weightValues2y.add(m.weight);
+    }
+
+    final frequency = min(count2y, 48) / 48;
+    final recency = max(0.0, (360 - daysSinceLast) / 360);
+    final variety = min(categoryIds2y.length, 10) / 10;
+    final weightVar = min(weightValues2y.length, 3) / 3;
+
+    final score =
+        (frequency * 35 + recency * 30 + variety * 20 + weightVar * 15)
+            .round();
+
+    return RelationshipScore(
+      score: score,
+      label: _labelForScore(score),
+      meetingsIn2y: count2y,
+      daysSinceLast: daysSinceLast,
+      distinctCategories2y: categoryIds2y.length,
+      distinctWeights2y: weightValues2y.length,
+    );
+  }
+
+  static String _labelForScore(int score) {
+    if (score >= 80) return 'Very close';
+    if (score >= 60) return 'Strong';
+    if (score >= 40) return 'Good';
+    if (score >= 20) return 'Fading';
+    return 'Distant';
+  }
+}

--- a/lib/presentation/ai_chat/ai_chat_provider.dart
+++ b/lib/presentation/ai_chat/ai_chat_provider.dart
@@ -5,9 +5,12 @@ import '../../data/models/ai_exceptions.dart';
 import '../../data/models/buddy_context.dart';
 import '../../data/models/chat_message.dart';
 import '../../data/models/meeting.dart';
+import '../../data/models/person.dart';
 import '../../data/services/buddy_write_service.dart';
 import '../../data/services/context_builder_service.dart';
+import '../../data/services/local_cache_service.dart';
 import '../../data/services/open_ai_service.dart';
+import '../../data/services/relationship_score_service.dart';
 import 'birthday_format_helpers.dart';
 import 'buddy_chat_mode.dart';
 
@@ -19,14 +22,18 @@ class AIChatProvider extends ChangeNotifier {
     OpenAIService? openAIService,
     ContextBuilderService? contextBuilderService,
     BuddyWriteService? buddyWriteService,
+    RelationshipScoreService? relationshipScoreService,
   })  : _openAIService = openAIService ?? OpenAIService(),
         _contextBuilderService =
             contextBuilderService ?? ContextBuilderService(),
-        _buddyWriteService = buddyWriteService ?? BuddyWriteService();
+        _buddyWriteService = buddyWriteService ?? BuddyWriteService(),
+        _relationshipScoreService =
+            relationshipScoreService ?? RelationshipScoreService();
 
   final OpenAIService _openAIService;
   final ContextBuilderService _contextBuilderService;
   final BuddyWriteService _buddyWriteService;
+  final RelationshipScoreService _relationshipScoreService;
 
   static final _dateFormat = DateFormat('dd MMM yyyy');
 
@@ -41,6 +48,8 @@ class AIChatProvider extends ChangeNotifier {
   bool _disposed = false;
 
   List<BuddyAction>? _pendingActions;
+  String? _pendingDisambiguationMessage;
+  List<Person> _pendingDisambiguationPersons = [];
   List<Meeting> _meetingOptions = [];
   List<BirthdayPersonInfo> _birthdayOptions = [];
   List<LapsedPersonInfo> _lapsedOptions = [];
@@ -314,6 +323,37 @@ class AIChatProvider extends ChangeNotifier {
       _safeNotify();
       return;
     }
+
+    // User selected the correct person from a disambiguation prompt.
+    if (action.actionId.startsWith('disambiguate_person:')) {
+      final personId = action.actionId.split(':')[1];
+      final text = _pendingDisambiguationMessage ?? '';
+      final matchedPersons = List<Person>.from(_pendingDisambiguationPersons);
+      _pendingDisambiguationMessage = null;
+      _pendingDisambiguationPersons = [];
+
+      _messages = [
+        ..._messages,
+        ChatMessage(role: 'user', content: action.label),
+      ];
+      _isLoading = true;
+      _safeNotify();
+
+      Person? person;
+      for (final p in matchedPersons) {
+        if (p.id == personId) {
+          person = p;
+          break;
+        }
+      }
+      final pseudonym = _context!.personIdToPseudonym[personId] ?? '';
+      final effectiveText = (person != null && pseudonym.isNotEmpty)
+          ? _replacePersonInText(text, person, pseudonym)
+          : text;
+
+      await _sendToBuddy(effectiveText);
+      return;
+    }
   }
 
   Future<String> _buildGreeting() async {
@@ -441,6 +481,8 @@ class AIChatProvider extends ChangeNotifier {
 
   /// Sends [text] to the AI and streams the response into a new message bubble.
   /// Clears any pending action buttons — a free-text message dismisses them.
+  /// If the text mentions a person ambiguously (multiple matches), shows
+  /// disambiguation buttons instead of sending immediately.
   Future<void> sendMessage(String text) async {
     _pendingActions = null;
     _messages = [..._messages, ChatMessage(role: 'user', content: text)];
@@ -448,29 +490,53 @@ class AIChatProvider extends ChangeNotifier {
     _errorMessage = null;
     _safeNotify();
 
+    final matches = await _findMatchingPersons(text);
+
+    if (matches.length > 1) {
+      // Ambiguous name — ask the user to pick before sending to AI.
+      _isLoading = false;
+      await _showPersonDisambiguation(text, matches);
+      return;
+    }
+
+    String effectiveText;
+    if (matches.length == 1) {
+      final person = matches.first;
+      final pseudonym = _context!.personIdToPseudonym[person.id] ?? '';
+      effectiveText = pseudonym.isNotEmpty
+          ? _replacePersonInText(text, person, pseudonym)
+          : text;
+    } else {
+      // No cache match — fall back to exact full-name replacement from context.
+      effectiveText = _translateRealNamesToPseudonyms(
+          text, _context!.pseudonymToRealName);
+    }
+
+    await _sendToBuddy(effectiveText);
+  }
+
+  /// Sends [effectiveText] (already pseudonymised) to the AI and appends
+  /// the translated response as a new assistant message.
+  Future<void> _sendToBuddy(String effectiveText) async {
     try {
-      final contextPrompt = _contextBuilderService.serializeToPrompt(
+      final contextPrompt =
+          await _contextBuilderService.serializeToPromptWithScores(
         _context!,
+        _userId!,
         includeNotes: _activeMeetingId != null,
       );
-
-      // History = all messages except the initial Buddy greeting (index 0).
       final history =
           _messages.length > 1 ? _messages.sublist(1) : <ChatMessage>[];
-
       final buffer = StringBuffer();
       await for (final chunk in _openAIService.sendMessage(
         contextPrompt,
         history,
-        text,
+        effectiveText,
       )) {
         buffer.write(chunk);
       }
-
       final translated = _translatePseudonyms(
-        buffer.toString(),
-        _context!.pseudonymToRealName,
-      );
+          buffer.toString(), _context!.pseudonymToRealName);
       _messages = [
         ..._messages,
         ChatMessage(role: 'assistant', content: translated),
@@ -520,11 +586,100 @@ class AIChatProvider extends ChangeNotifier {
     if (!_disposed) notifyListeners();
   }
 
+  /// Returns persons from the current context whose name tokens (firstName,
+  /// lastName, nicknames ≥ 3 chars) appear as substrings in [text].
+  Future<List<Person>> _findMatchingPersons(String text) async {
+    if (_context == null || _userId == null) return [];
+    final allPersons = await LocalCacheService().getAllPersons(_userId!);
+    final contextIds = _context!.personIdToPseudonym.keys.toSet();
+    final lower = text.toLowerCase();
+    final result = <Person>[];
+    for (final person in allPersons) {
+      if (!contextIds.contains(person.id)) continue;
+      final tokens = [
+        person.firstName,
+        if (person.lastName != null) person.lastName!,
+        ...person.nicknames,
+      ].where((t) => t.length >= 3);
+      if (tokens.any((t) => lower.contains(t.toLowerCase()))) {
+        result.add(person);
+      }
+    }
+    return result;
+  }
+
+  /// Replaces all name variants of [person] in [text] with [pseudonym].
+  /// Longest variants are replaced first to avoid partial replacements.
+  String _replacePersonInText(String text, Person person, String pseudonym) {
+    final variants = [
+      person.fullName,
+      person.firstName,
+      if (person.lastName != null) person.lastName!,
+      ...person.nicknames,
+    ]..sort((a, b) => b.length.compareTo(a.length));
+    var result = text;
+    for (final v in variants) {
+      result = result.replaceAll(
+        RegExp(RegExp.escape(v), caseSensitive: false),
+        pseudonym,
+      );
+    }
+    return result;
+  }
+
+  /// Shows an assistant message asking the user to clarify which person they
+  /// meant, with one action button per candidate (showing their score).
+  Future<void> _showPersonDisambiguation(
+      String text, List<Person> persons) async {
+    _pendingDisambiguationMessage = text;
+    _pendingDisambiguationPersons = List<Person>.from(persons);
+    const reply = "I'm not sure who you mean — did you mean:";
+    _messages = [
+      ..._messages,
+      const ChatMessage(role: 'assistant', content: reply),
+    ];
+    final actions = <BuddyAction>[];
+    for (final person in persons) {
+      RelationshipScore? score;
+      try {
+        score =
+            await _relationshipScoreService.computeScore(_userId!, person.id);
+      } catch (_) {
+        // Show button without score if computation fails.
+      }
+      final scoreStr = score != null ? ' — score ${score.score}/100' : '';
+      actions.add(BuddyAction(
+        label: '${person.fullName}$scoreStr',
+        actionId: 'disambiguate_person:${person.id}',
+      ));
+    }
+    _pendingActions = actions;
+    _safeNotify();
+  }
+
   String _translatePseudonyms(
       String text, Map<String, String> pseudonymToReal) {
     // Sort longest-first to prevent shorter pseudonyms (Friend_A) from
     // partially replacing longer ones (Friend_AH → "Ada MachuraH").
     final sorted = pseudonymToReal.entries.toList()
+      ..sort((a, b) => b.key.length.compareTo(a.key.length));
+    var result = text;
+    for (final entry in sorted) {
+      result = result.replaceAll(entry.key, entry.value);
+    }
+    return result;
+  }
+
+  // Translates real names in user input to pseudonyms before sending to AI.
+  // This is the inverse of _translatePseudonyms and ensures Buddy can match
+  // names the user types (e.g. "Anna Hill") to the pseudonyms in its context.
+  // Longest real names are replaced first to avoid partial matches.
+  String _translateRealNamesToPseudonyms(
+      String text, Map<String, String> pseudonymToReal) {
+    final realToPseudonym = {
+      for (final e in pseudonymToReal.entries) e.value: e.key,
+    };
+    final sorted = realToPseudonym.entries.toList()
       ..sort((a, b) => b.key.length.compareTo(a.key.length));
     var result = text;
     for (final entry in sorted) {

--- a/lib/presentation/ai_chat/ai_chat_provider.dart
+++ b/lib/presentation/ai_chat/ai_chat_provider.dart
@@ -1,4 +1,4 @@
-﻿import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';
 
 import '../../data/models/ai_exceptions.dart';
@@ -508,8 +508,8 @@ class AIChatProvider extends ChangeNotifier {
           : text;
     } else {
       // No cache match — fall back to exact full-name replacement from context.
-      effectiveText = _translateRealNamesToPseudonyms(
-          text, _context!.pseudonymToRealName);
+      effectiveText =
+          _translateRealNamesToPseudonyms(text, _context!.pseudonymToRealName);
     }
 
     await _sendToBuddy(effectiveText);

--- a/lib/presentation/persons/person_detail_provider.dart
+++ b/lib/presentation/persons/person_detail_provider.dart
@@ -5,6 +5,7 @@ import '../../data/repositories/meeting_repository.dart';
 import '../../data/repositories/person_repository.dart';
 import '../../data/repositories/sharing_token_repository.dart';
 import '../../data/services/auth_service.dart';
+import '../../data/services/relationship_score_service.dart';
 
 // PersonDetailProvider manages state for PersonDetailScreen.
 // Responsibilities: hold person data, fetch meeting count, update, delete, link account.
@@ -13,20 +14,25 @@ class PersonDetailProvider extends ChangeNotifier {
   final MeetingRepository _meetingRepository;
   final AuthService _authService;
   final SharingTokenRepository _sharingTokenRepository;
+  final RelationshipScoreService _relationshipScoreService;
 
   PersonDetailProvider({
     required PersonRepository personRepository,
     required MeetingRepository meetingRepository,
     required AuthService authService,
     SharingTokenRepository? sharingTokenRepository,
+    RelationshipScoreService? relationshipScoreService,
   })  : _personRepository = personRepository,
         _meetingRepository = meetingRepository,
         _authService = authService,
         _sharingTokenRepository =
-            sharingTokenRepository ?? SharingTokenRepository();
+            sharingTokenRepository ?? SharingTokenRepository(),
+        _relationshipScoreService =
+            relationshipScoreService ?? RelationshipScoreService();
 
   Person? _person;
   int _meetingCount = 0;
+  RelationshipScore? _score;
   bool _isLoading = false;
   bool _isDeleting = false;
   bool _isLinking = false;
@@ -34,12 +40,13 @@ class PersonDetailProvider extends ChangeNotifier {
 
   Person? get person => _person;
   int get meetingCount => _meetingCount;
+  RelationshipScore? get score => _score;
   bool get isLoading => _isLoading;
   bool get isDeleting => _isDeleting;
   bool get isLinking => _isLinking;
   String? get errorMessage => _errorMessage;
 
-  // Stores the person and fetches the meeting count for them.
+  // Stores the person, fetches the meeting count, and computes the relationship score.
   Future<void> initialize(Person person) async {
     _person = person;
     _isLoading = true;
@@ -50,6 +57,7 @@ class PersonDetailProvider extends ChangeNotifier {
       final userId = _authService.currentUserId!;
       _meetingCount =
           await _meetingRepository.getMeetingsCountForPerson(userId, person.id);
+      _score = await _relationshipScoreService.computeScore(userId, person.id);
     } catch (e) {
       _errorMessage = e.toString();
     } finally {

--- a/lib/presentation/persons/person_detail_screen.dart
+++ b/lib/presentation/persons/person_detail_screen.dart
@@ -16,6 +16,7 @@ import 'friend_groups_provider.dart';
 import 'nicknames_section.dart';
 import 'person_detail_provider.dart';
 import 'person_meetings_screen.dart';
+import 'relationship_strength_widget.dart';
 
 /// Displays full details of a single person and supports edit, delete, and account linking.
 class PersonDetailScreen extends StatefulWidget {
@@ -537,6 +538,8 @@ class _PersonDetailBody extends StatelessWidget {
 
     return ListView(
       children: [
+        if (provider.score != null)
+          RelationshipStrengthWidget(score: provider.score!),
         ListTile(
           title: const Text('First Name'),
           subtitle: Text(person.firstName),

--- a/lib/presentation/persons/relationship_strength_widget.dart
+++ b/lib/presentation/persons/relationship_strength_widget.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+import '../../data/services/relationship_score_service.dart';
+
+// Displays the relationship strength score as a colored progress bar with a label.
+// Score range: 0–100. Color and label are determined by the score value.
+class RelationshipStrengthWidget extends StatelessWidget {
+  final RelationshipScore score;
+
+  const RelationshipStrengthWidget({super.key, required this.score});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final barColor = _barColor(score.score);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Relationship Strength', style: theme.textTheme.titleMedium),
+          const SizedBox(height: 8),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: LinearProgressIndicator(
+              value: score.score / 100,
+              color: barColor,
+              minHeight: 8,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text('${score.score}/100'),
+              Text(score.label),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+Color _barColor(int score) {
+  if (score >= 80) return Colors.green;
+  if (score >= 60) return Colors.lightGreen;
+  if (score >= 40) return Colors.amber;
+  if (score >= 20) return Colors.orange;
+  return Colors.red;
+}

--- a/test/data/services/context_builder_service_test.dart
+++ b/test/data/services/context_builder_service_test.dart
@@ -7,13 +7,18 @@ import 'package:friendsheet/data/repositories/activity_category_repository.dart'
 import 'package:friendsheet/data/repositories/meeting_repository.dart';
 import 'package:friendsheet/data/repositories/person_repository.dart';
 import 'package:friendsheet/data/services/context_builder_service.dart';
+import 'package:friendsheet/data/services/relationship_score_service.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 
 import 'context_builder_service_test.mocks.dart';
 
-@GenerateMocks(
-    [MeetingRepository, PersonRepository, ActivityCategoryRepository])
+@GenerateMocks([
+  MeetingRepository,
+  PersonRepository,
+  ActivityCategoryRepository,
+  RelationshipScoreService,
+])
 void main() {
   late MockMeetingRepository mockMeetingRepo;
   late MockPersonRepository mockPersonRepo;
@@ -719,6 +724,74 @@ void main() {
 
       expect(output, isNot(contains('avg cadence')));
       expect(output, isNot(contains('days since last meeting')));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // serializeToPromptWithScores
+  // ---------------------------------------------------------------------------
+
+  group('serializeToPromptWithScores', () {
+    late MockRelationshipScoreService mockScoreService;
+    late ContextBuilderService serviceWithScores;
+
+    const stubScore = RelationshipScore(
+      score: 55,
+      label: 'Good',
+      meetingsIn2y: 10,
+      daysSinceLast: 30,
+      distinctCategories2y: 3,
+      distinctWeights2y: 2,
+    );
+
+    setUp(() {
+      mockScoreService = MockRelationshipScoreService();
+      serviceWithScores = ContextBuilderService(
+        meetingRepository: mockMeetingRepo,
+        personRepository: mockPersonRepo,
+        activityCategoryRepository: mockCategoryRepo,
+        relationshipScoreService: mockScoreService,
+      );
+    });
+
+    test('appends Relationship Scores section with pseudonym and score',
+        () async {
+      when(mockScoreService.computeScore(any, any))
+          .thenAnswer((_) async => stubScore);
+
+      const ctx = BuddyContext(
+        meetings: [],
+        persons: [
+          PersonContextEntry(
+            pseudonym: 'Friend_A',
+            meetingCount: 10,
+            topActivities: [],
+          ),
+        ],
+        pseudonymToRealName: {'Friend_A': 'Anna Kowalska'},
+        personIdToPseudonym: {'p1': 'Friend_A'},
+      );
+
+      final output =
+          await serviceWithScores.serializeToPromptWithScores(ctx, 'user-1');
+
+      expect(output, contains('### Relationship Scores'));
+      expect(output, contains('Friend_A: score 55/100 (Good)'));
+    });
+
+    test('returns base prompt only when persons list is empty', () async {
+      const emptyCtx = BuddyContext(
+        meetings: [],
+        persons: [],
+        pseudonymToRealName: {},
+        personIdToPseudonym: {},
+      );
+
+      final output = await serviceWithScores.serializeToPromptWithScores(
+          emptyCtx, 'user-1');
+
+      expect(output, isNot(contains('### Relationship Scores')));
+      verifyNever(mockScoreService.computeScore(any, any));
     });
   });
 }

--- a/test/data/services/context_builder_service_test.mocks.dart
+++ b/test/data/services/context_builder_service_test.mocks.dart
@@ -3,18 +3,20 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i6;
+import 'dart:async' as _i7;
 
 import 'package:friendsheet/data/models/activity_category.dart' as _i3;
-import 'package:friendsheet/data/models/meeting.dart' as _i7;
+import 'package:friendsheet/data/models/meeting.dart' as _i8;
 import 'package:friendsheet/data/models/person.dart' as _i2;
 import 'package:friendsheet/data/repositories/activity_category_repository.dart'
-    as _i10;
-import 'package:friendsheet/data/repositories/cache_invalidator.dart' as _i5;
-import 'package:friendsheet/data/repositories/meeting_repository.dart' as _i4;
-import 'package:friendsheet/data/repositories/person_repository.dart' as _i9;
+    as _i11;
+import 'package:friendsheet/data/repositories/cache_invalidator.dart' as _i6;
+import 'package:friendsheet/data/repositories/meeting_repository.dart' as _i5;
+import 'package:friendsheet/data/repositories/person_repository.dart' as _i10;
+import 'package:friendsheet/data/services/relationship_score_service.dart'
+    as _i4;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i8;
+import 'package:mockito/src/dummies.dart' as _i9;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -51,16 +53,27 @@ class _FakeActivityCategory_1 extends _i1.SmartFake
         );
 }
 
+class _FakeRelationshipScore_2 extends _i1.SmartFake
+    implements _i4.RelationshipScore {
+  _FakeRelationshipScore_2(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [MeetingRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMeetingRepository extends _i1.Mock implements _i4.MeetingRepository {
+class MockMeetingRepository extends _i1.Mock implements _i5.MeetingRepository {
   MockMeetingRepository() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  set cacheInvalidator(_i5.CacheInvalidator? _cacheInvalidator) =>
+  set cacheInvalidator(_i6.CacheInvalidator? _cacheInvalidator) =>
       super.noSuchMethod(
         Invocation.setter(
           #cacheInvalidator,
@@ -70,52 +83,52 @@ class MockMeetingRepository extends _i1.Mock implements _i4.MeetingRepository {
       );
 
   @override
-  _i6.Future<String> saveMeeting(_i7.Meeting? meeting) => (super.noSuchMethod(
+  _i7.Future<String> saveMeeting(_i8.Meeting? meeting) => (super.noSuchMethod(
         Invocation.method(
           #saveMeeting,
           [meeting],
         ),
-        returnValue: _i6.Future<String>.value(_i8.dummyValue<String>(
+        returnValue: _i7.Future<String>.value(_i9.dummyValue<String>(
           this,
           Invocation.method(
             #saveMeeting,
             [meeting],
           ),
         )),
-      ) as _i6.Future<String>);
+      ) as _i7.Future<String>);
 
   @override
-  _i6.Stream<List<_i7.Meeting>> getMeetingsByUser(String? userId) =>
+  _i7.Stream<List<_i8.Meeting>> getMeetingsByUser(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getMeetingsByUser,
           [userId],
         ),
-        returnValue: _i6.Stream<List<_i7.Meeting>>.empty(),
-      ) as _i6.Stream<List<_i7.Meeting>>);
+        returnValue: _i7.Stream<List<_i8.Meeting>>.empty(),
+      ) as _i7.Stream<List<_i8.Meeting>>);
 
   @override
-  _i6.Future<List<_i7.Meeting>> getAllMeetings(String? userId) =>
+  _i7.Future<List<_i8.Meeting>> getAllMeetings(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getAllMeetings,
           [userId],
         ),
-        returnValue: _i6.Future<List<_i7.Meeting>>.value(<_i7.Meeting>[]),
-      ) as _i6.Future<List<_i7.Meeting>>);
+        returnValue: _i7.Future<List<_i8.Meeting>>.value(<_i8.Meeting>[]),
+      ) as _i7.Future<List<_i8.Meeting>>);
 
   @override
-  _i6.Future<void> updateMeeting(_i7.Meeting? meeting) => (super.noSuchMethod(
+  _i7.Future<void> updateMeeting(_i8.Meeting? meeting) => (super.noSuchMethod(
         Invocation.method(
           #updateMeeting,
           [meeting],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<void> deleteMeeting(
+  _i7.Future<void> deleteMeeting(
     String? userId,
     String? meetingId,
   ) =>
@@ -127,12 +140,12 @@ class MockMeetingRepository extends _i1.Mock implements _i4.MeetingRepository {
             meetingId,
           ],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<List<_i7.Meeting>> getMeetingsByParticipant(
+  _i7.Future<List<_i8.Meeting>> getMeetingsByParticipant(
     String? userId,
     String? personId,
   ) =>
@@ -144,11 +157,11 @@ class MockMeetingRepository extends _i1.Mock implements _i4.MeetingRepository {
             personId,
           ],
         ),
-        returnValue: _i6.Future<List<_i7.Meeting>>.value(<_i7.Meeting>[]),
-      ) as _i6.Future<List<_i7.Meeting>>);
+        returnValue: _i7.Future<List<_i8.Meeting>>.value(<_i8.Meeting>[]),
+      ) as _i7.Future<List<_i8.Meeting>>);
 
   @override
-  _i6.Future<int> getMeetingsCountForPerson(
+  _i7.Future<int> getMeetingsCountForPerson(
     String? userId,
     String? personId,
   ) =>
@@ -160,11 +173,11 @@ class MockMeetingRepository extends _i1.Mock implements _i4.MeetingRepository {
             personId,
           ],
         ),
-        returnValue: _i6.Future<int>.value(0),
-      ) as _i6.Future<int>);
+        returnValue: _i7.Future<int>.value(0),
+      ) as _i7.Future<int>);
 
   @override
-  _i6.Future<void> replaceCategoryInMeetings(
+  _i7.Future<void> replaceCategoryInMeetings(
     String? userId,
     String? sourceId,
     String? targetId,
@@ -178,12 +191,12 @@ class MockMeetingRepository extends _i1.Mock implements _i4.MeetingRepository {
             targetId,
           ],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<_i7.Meeting?> getLastMeetingWithoutNotes(
+  _i7.Future<_i8.Meeting?> getLastMeetingWithoutNotes(
     String? userId,
     DateTime? since,
   ) =>
@@ -195,11 +208,11 @@ class MockMeetingRepository extends _i1.Mock implements _i4.MeetingRepository {
             since,
           ],
         ),
-        returnValue: _i6.Future<_i7.Meeting?>.value(),
-      ) as _i6.Future<_i7.Meeting?>);
+        returnValue: _i7.Future<_i8.Meeting?>.value(),
+      ) as _i7.Future<_i8.Meeting?>);
 
   @override
-  _i6.Future<List<_i7.Meeting>> getRecentMeetingsWithoutNotes(
+  _i7.Future<List<_i8.Meeting>> getRecentMeetingsWithoutNotes(
     String? userId,
     DateTime? since, {
     int? limit = 3,
@@ -213,11 +226,11 @@ class MockMeetingRepository extends _i1.Mock implements _i4.MeetingRepository {
           ],
           {#limit: limit},
         ),
-        returnValue: _i6.Future<List<_i7.Meeting>>.value(<_i7.Meeting>[]),
-      ) as _i6.Future<List<_i7.Meeting>>);
+        returnValue: _i7.Future<List<_i8.Meeting>>.value(<_i8.Meeting>[]),
+      ) as _i7.Future<List<_i8.Meeting>>);
 
   @override
-  _i6.Future<Set<String>> getPersonIdsSeenSince(
+  _i7.Future<Set<String>> getPersonIdsSeenSince(
     String? userId,
     DateTime? since,
   ) =>
@@ -229,11 +242,11 @@ class MockMeetingRepository extends _i1.Mock implements _i4.MeetingRepository {
             since,
           ],
         ),
-        returnValue: _i6.Future<Set<String>>.value(<String>{}),
-      ) as _i6.Future<Set<String>>);
+        returnValue: _i7.Future<Set<String>>.value(<String>{}),
+      ) as _i7.Future<Set<String>>);
 
   @override
-  _i6.Future<List<_i7.Meeting>> getRecentMeetingsByPerson(
+  _i7.Future<List<_i8.Meeting>> getRecentMeetingsByPerson(
     String? userId,
     String? personId, {
     int? limit = 4,
@@ -247,11 +260,11 @@ class MockMeetingRepository extends _i1.Mock implements _i4.MeetingRepository {
           ],
           {#limit: limit},
         ),
-        returnValue: _i6.Future<List<_i7.Meeting>>.value(<_i7.Meeting>[]),
-      ) as _i6.Future<List<_i7.Meeting>>);
+        returnValue: _i7.Future<List<_i8.Meeting>>.value(<_i8.Meeting>[]),
+      ) as _i7.Future<List<_i8.Meeting>>);
 
   @override
-  _i6.Future<void> removePersonFromMeetings(
+  _i7.Future<void> removePersonFromMeetings(
     String? userId,
     String? personId,
   ) =>
@@ -263,21 +276,21 @@ class MockMeetingRepository extends _i1.Mock implements _i4.MeetingRepository {
             personId,
           ],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 }
 
 /// A class which mocks [PersonRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockPersonRepository extends _i1.Mock implements _i9.PersonRepository {
+class MockPersonRepository extends _i1.Mock implements _i10.PersonRepository {
   MockPersonRepository() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  set cacheInvalidator(_i5.CacheInvalidator? _cacheInvalidator) =>
+  set cacheInvalidator(_i6.CacheInvalidator? _cacheInvalidator) =>
       super.noSuchMethod(
         Invocation.setter(
           #cacheInvalidator,
@@ -287,17 +300,17 @@ class MockPersonRepository extends _i1.Mock implements _i9.PersonRepository {
       );
 
   @override
-  _i6.Future<List<_i2.Person>> getPersonsByUser(String? userId) =>
+  _i7.Future<List<_i2.Person>> getPersonsByUser(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPersonsByUser,
           [userId],
         ),
-        returnValue: _i6.Future<List<_i2.Person>>.value(<_i2.Person>[]),
-      ) as _i6.Future<List<_i2.Person>>);
+        returnValue: _i7.Future<List<_i2.Person>>.value(<_i2.Person>[]),
+      ) as _i7.Future<List<_i2.Person>>);
 
   @override
-  _i6.Future<List<_i2.Person>> getPersonsByIds(
+  _i7.Future<List<_i2.Person>> getPersonsByIds(
     List<String>? ids,
     String? userId,
   ) =>
@@ -309,36 +322,36 @@ class MockPersonRepository extends _i1.Mock implements _i9.PersonRepository {
             userId,
           ],
         ),
-        returnValue: _i6.Future<List<_i2.Person>>.value(<_i2.Person>[]),
-      ) as _i6.Future<List<_i2.Person>>);
+        returnValue: _i7.Future<List<_i2.Person>>.value(<_i2.Person>[]),
+      ) as _i7.Future<List<_i2.Person>>);
 
   @override
-  _i6.Future<_i2.Person> addPerson(_i2.Person? person) => (super.noSuchMethod(
+  _i7.Future<_i2.Person> addPerson(_i2.Person? person) => (super.noSuchMethod(
         Invocation.method(
           #addPerson,
           [person],
         ),
-        returnValue: _i6.Future<_i2.Person>.value(_FakePerson_0(
+        returnValue: _i7.Future<_i2.Person>.value(_FakePerson_0(
           this,
           Invocation.method(
             #addPerson,
             [person],
           ),
         )),
-      ) as _i6.Future<_i2.Person>);
+      ) as _i7.Future<_i2.Person>);
 
   @override
-  _i6.Future<void> updatePerson(_i2.Person? person) => (super.noSuchMethod(
+  _i7.Future<void> updatePerson(_i2.Person? person) => (super.noSuchMethod(
         Invocation.method(
           #updatePerson,
           [person],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<bool> isDuplicateName(
+  _i7.Future<bool> isDuplicateName(
     String? userId,
     String? firstName,
     String? lastName, {
@@ -354,11 +367,11 @@ class MockPersonRepository extends _i1.Mock implements _i9.PersonRepository {
           ],
           {#excludeId: excludeId},
         ),
-        returnValue: _i6.Future<bool>.value(false),
-      ) as _i6.Future<bool>);
+        returnValue: _i7.Future<bool>.value(false),
+      ) as _i7.Future<bool>);
 
   @override
-  _i6.Future<void> deletePerson(
+  _i7.Future<void> deletePerson(
     String? userId,
     String? personId,
   ) =>
@@ -370,22 +383,22 @@ class MockPersonRepository extends _i1.Mock implements _i9.PersonRepository {
             personId,
           ],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 }
 
 /// A class which mocks [ActivityCategoryRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockActivityCategoryRepository extends _i1.Mock
-    implements _i10.ActivityCategoryRepository {
+    implements _i11.ActivityCategoryRepository {
   MockActivityCategoryRepository() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  set cacheInvalidator(_i5.CacheInvalidator? _cacheInvalidator) =>
+  set cacheInvalidator(_i6.CacheInvalidator? _cacheInvalidator) =>
       super.noSuchMethod(
         Invocation.setter(
           #cacheInvalidator,
@@ -395,39 +408,39 @@ class MockActivityCategoryRepository extends _i1.Mock
       );
 
   @override
-  _i6.Stream<List<_i3.ActivityCategory>> getCategories(String? userId) =>
+  _i7.Stream<List<_i3.ActivityCategory>> getCategories(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getCategories,
           [userId],
         ),
-        returnValue: _i6.Stream<List<_i3.ActivityCategory>>.empty(),
-      ) as _i6.Stream<List<_i3.ActivityCategory>>);
+        returnValue: _i7.Stream<List<_i3.ActivityCategory>>.empty(),
+      ) as _i7.Stream<List<_i3.ActivityCategory>>);
 
   @override
-  _i6.Future<void> addCategory(_i3.ActivityCategory? category) =>
+  _i7.Future<void> addCategory(_i3.ActivityCategory? category) =>
       (super.noSuchMethod(
         Invocation.method(
           #addCategory,
           [category],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<void> updateCategory(_i3.ActivityCategory? category) =>
+  _i7.Future<void> updateCategory(_i3.ActivityCategory? category) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateCategory,
           [category],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<void> deleteCategory(
+  _i7.Future<void> deleteCategory(
     String? userId,
     String? categoryId,
   ) =>
@@ -439,12 +452,12 @@ class MockActivityCategoryRepository extends _i1.Mock
             categoryId,
           ],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<void> deleteWithChildren(
+  _i7.Future<void> deleteWithChildren(
     String? userId,
     String? categoryId,
   ) =>
@@ -456,12 +469,12 @@ class MockActivityCategoryRepository extends _i1.Mock
             categoryId,
           ],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<_i3.ActivityCategory> createSelectableCategory({
+  _i7.Future<_i3.ActivityCategory> createSelectableCategory({
     required String? name,
     required String? userId,
   }) =>
@@ -475,7 +488,7 @@ class MockActivityCategoryRepository extends _i1.Mock
           },
         ),
         returnValue:
-            _i6.Future<_i3.ActivityCategory>.value(_FakeActivityCategory_1(
+            _i7.Future<_i3.ActivityCategory>.value(_FakeActivityCategory_1(
           this,
           Invocation.method(
             #createSelectableCategory,
@@ -486,22 +499,22 @@ class MockActivityCategoryRepository extends _i1.Mock
             },
           ),
         )),
-      ) as _i6.Future<_i3.ActivityCategory>);
+      ) as _i7.Future<_i3.ActivityCategory>);
 
   @override
-  _i6.Future<List<_i3.ActivityCategory>> getSelectableCategories(
+  _i7.Future<List<_i3.ActivityCategory>> getSelectableCategories(
           String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getSelectableCategories,
           [userId],
         ),
-        returnValue: _i6.Future<List<_i3.ActivityCategory>>.value(
+        returnValue: _i7.Future<List<_i3.ActivityCategory>>.value(
             <_i3.ActivityCategory>[]),
-      ) as _i6.Future<List<_i3.ActivityCategory>>);
+      ) as _i7.Future<List<_i3.ActivityCategory>>);
 
   @override
-  _i6.Future<List<String>> getAncestorIds(
+  _i7.Future<List<String>> getAncestorIds(
     String? categoryId,
     String? userId,
   ) =>
@@ -513,22 +526,22 @@ class MockActivityCategoryRepository extends _i1.Mock
             userId,
           ],
         ),
-        returnValue: _i6.Future<List<String>>.value(<String>[]),
-      ) as _i6.Future<List<String>>);
+        returnValue: _i7.Future<List<String>>.value(<String>[]),
+      ) as _i7.Future<List<String>>);
 
   @override
-  _i6.Future<List<_i3.ActivityCategory>> getAllCategories(String? userId) =>
+  _i7.Future<List<_i3.ActivityCategory>> getAllCategories(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getAllCategories,
           [userId],
         ),
-        returnValue: _i6.Future<List<_i3.ActivityCategory>>.value(
+        returnValue: _i7.Future<List<_i3.ActivityCategory>>.value(
             <_i3.ActivityCategory>[]),
-      ) as _i6.Future<List<_i3.ActivityCategory>>);
+      ) as _i7.Future<List<_i3.ActivityCategory>>);
 
   @override
-  _i6.Future<List<_i3.ActivityCategory>> getCategoriesByIds(
+  _i7.Future<List<_i3.ActivityCategory>> getCategoriesByIds(
     List<String>? ids,
     String? userId,
   ) =>
@@ -540,7 +553,43 @@ class MockActivityCategoryRepository extends _i1.Mock
             userId,
           ],
         ),
-        returnValue: _i6.Future<List<_i3.ActivityCategory>>.value(
+        returnValue: _i7.Future<List<_i3.ActivityCategory>>.value(
             <_i3.ActivityCategory>[]),
-      ) as _i6.Future<List<_i3.ActivityCategory>>);
+      ) as _i7.Future<List<_i3.ActivityCategory>>);
+}
+
+/// A class which mocks [RelationshipScoreService].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockRelationshipScoreService extends _i1.Mock
+    implements _i4.RelationshipScoreService {
+  MockRelationshipScoreService() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i7.Future<_i4.RelationshipScore> computeScore(
+    String? userId,
+    String? personId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #computeScore,
+          [
+            userId,
+            personId,
+          ],
+        ),
+        returnValue:
+            _i7.Future<_i4.RelationshipScore>.value(_FakeRelationshipScore_2(
+          this,
+          Invocation.method(
+            #computeScore,
+            [
+              userId,
+              personId,
+            ],
+          ),
+        )),
+      ) as _i7.Future<_i4.RelationshipScore>);
 }

--- a/test/data/services/relationship_score_service_test.dart
+++ b/test/data/services/relationship_score_service_test.dart
@@ -1,0 +1,161 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:friendsheet/data/models/meeting.dart';
+import 'package:friendsheet/data/services/local_cache_service.dart';
+import 'package:friendsheet/data/services/relationship_score_service.dart';
+import 'package:friendsheet/services/hive_service.dart';
+import 'package:hive/hive.dart';
+
+void main() {
+  late Directory tempDir;
+  final service = RelationshipScoreService();
+
+  Meeting makeMeeting({
+    required String id,
+    required DateTime date,
+    List<String> participantIds = const ['p1'],
+    List<String> categoryIds = const ['cat1'],
+    int weight = 3,
+  }) =>
+      Meeting(
+        id: id,
+        userId: 'u1',
+        name: 'M$id',
+        date: date,
+        weight: weight,
+        participantIds: participantIds,
+        categoryIds: categoryIds,
+        notes: const [],
+        createdAt: date,
+        updatedAt: date,
+      );
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('hive_rss_test_');
+    await HiveService.initialize(testPath: tempDir.path);
+  });
+
+  tearDownAll(() async {
+    await Hive.close();
+    await tempDir.delete(recursive: true);
+  });
+
+  setUp(() async {
+    await HiveService.clearUserData('u1');
+  });
+
+  // ---------------------------------------------------------------------------
+  // computeScore
+  // ---------------------------------------------------------------------------
+
+  group('computeScore', () {
+    test('returns Distant/0 with -1 daysSinceLast when no meetings', () async {
+      final result = await service.computeScore('u1', 'p1');
+
+      expect(result.score, 0);
+      expect(result.label, 'Distant');
+      expect(result.daysSinceLast, -1);
+      expect(result.meetingsIn2y, 0);
+      expect(result.distinctCategories2y, 0);
+      expect(result.distinctWeights2y, 0);
+    });
+
+    test('computes correct score and fields for meetings within 2y window',
+        () async {
+      final now = DateTime.now();
+      // 12 meetings, each 10 days apart (0–110 days ago) — all within 730-day window.
+      // 3 distinct categories (i%3), 2 distinct weights (3 and 5).
+      final meetings = List.generate(
+        12,
+        (i) => makeMeeting(
+          id: 'm$i',
+          date: now.subtract(Duration(days: i * 10)),
+          categoryIds: ['cat${i % 3}'],
+          weight: i % 2 == 0 ? 3 : 5,
+        ),
+      );
+      for (final m in meetings) {
+        await LocalCacheService().upsertMeeting('u1', m);
+      }
+
+      final result = await service.computeScore('u1', 'p1');
+
+      // Expected partial scores:
+      //   freq    = min(12,48)/48 * 35 = 0.25 * 35 = 8.75 → rounds to 9
+      //   recency = (360-0)/360 * 30  = 1.0  * 30 = 30.0 → rounds to 30
+      //   variety = min(3,10)/10 * 20 = 0.3  * 20 = 6.0  → rounds to 6
+      //   weightV = min(2,3)/3 * 15   = 0.667* 15 = 10.0 → rounds to 10
+      //   total = 9+30+6+10 = 55
+      expect(result.score, 55);
+      expect(result.label, 'Good');
+      expect(result.meetingsIn2y, 12);
+      expect(result.daysSinceLast, 0);
+      expect(result.distinctCategories2y, 3);
+      expect(result.distinctWeights2y, 2);
+    });
+
+    test('uses all-time last meeting for recency — not limited to 2y window',
+        () async {
+      final now = DateTime.now();
+      // Only meeting is 800 days ago — outside the 730-day 2y window.
+      await LocalCacheService().upsertMeeting(
+        'u1',
+        makeMeeting(id: 'old', date: now.subtract(const Duration(days: 800))),
+      );
+
+      final result = await service.computeScore('u1', 'p1');
+
+      // daysSinceLast must reflect the real last meeting, not return -1.
+      expect(result.daysSinceLast, 800);
+      // No meetings within the 2y window.
+      expect(result.meetingsIn2y, 0);
+      expect(result.distinctCategories2y, 0);
+    });
+
+    test('returns Very close / 100 when all factors hit their caps', () async {
+      final now = DateTime.now();
+      // 48 meetings every 14 days (max 47*14=658 days ago — within 730-day cap).
+      // 10 distinct categories, 3 distinct weights.
+      final meetings = List.generate(
+        48,
+        (i) => makeMeeting(
+          id: 'm$i',
+          date: now.subtract(Duration(days: i * 14)),
+          categoryIds: ['cat${i % 10}'],
+          weight: [1, 3, 5][i % 3],
+        ),
+      );
+      for (final m in meetings) {
+        await LocalCacheService().upsertMeeting('u1', m);
+      }
+
+      final result = await service.computeScore('u1', 'p1');
+
+      expect(result.score, 100);
+      expect(result.label, 'Very close');
+    });
+
+    test('score label boundaries — Fading for score 20–39', () async {
+      final now = DateTime.now();
+      // One meeting 300 days ago: recency = (360-300)/360 * 30 = 5.0 → 5pts, rest = 0.
+      // Score = 5, label = 'Distant' — adjust: need ~20pts.
+      // 2 meetings/2y (freq=2/48=0.042→1pt), recency 200d ago (360-200)/360*30=13.3→13pts,
+      // 1 category (0.1*20=2→2pts), 1 weight (1/3*15=5→5pts): 1+13+2+5=21pts → 'Fading'.
+      await LocalCacheService().upsertMeeting(
+        'u1',
+        makeMeeting(id: 'm1', date: now.subtract(const Duration(days: 200))),
+      );
+      await LocalCacheService().upsertMeeting(
+        'u1',
+        makeMeeting(id: 'm2', date: now.subtract(const Duration(days: 250))),
+      );
+
+      final result = await service.computeScore('u1', 'p1');
+
+      expect(result.score, greaterThanOrEqualTo(20));
+      expect(result.score, lessThan(40));
+      expect(result.label, 'Fading');
+    });
+  });
+}

--- a/test/presentation/persons/person_detail_provider_test.dart
+++ b/test/presentation/persons/person_detail_provider_test.dart
@@ -4,20 +4,36 @@ import 'package:friendsheet/data/repositories/meeting_repository.dart';
 import 'package:friendsheet/data/repositories/person_repository.dart';
 import 'package:friendsheet/data/repositories/sharing_token_repository.dart';
 import 'package:friendsheet/data/services/auth_service.dart';
+import 'package:friendsheet/data/services/relationship_score_service.dart';
 import 'package:friendsheet/presentation/persons/person_detail_provider.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 
 import 'person_detail_provider_test.mocks.dart';
 
-@GenerateMocks(
-    [PersonRepository, MeetingRepository, AuthService, SharingTokenRepository])
+@GenerateMocks([
+  PersonRepository,
+  MeetingRepository,
+  AuthService,
+  SharingTokenRepository,
+  RelationshipScoreService,
+])
 void main() {
   late MockPersonRepository mockPersonRepository;
   late MockMeetingRepository mockMeetingRepository;
   late MockAuthService mockAuthService;
   late MockSharingTokenRepository mockSharingTokenRepository;
+  late MockRelationshipScoreService mockRelationshipScoreService;
   late PersonDetailProvider provider;
+
+  const stubScore = RelationshipScore(
+    score: 50,
+    label: 'Good',
+    meetingsIn2y: 10,
+    daysSinceLast: 30,
+    distinctCategories2y: 3,
+    distinctWeights2y: 2,
+  );
 
   final testPerson = Person(
     id: 'p1',
@@ -32,12 +48,16 @@ void main() {
     mockMeetingRepository = MockMeetingRepository();
     mockAuthService = MockAuthService();
     mockSharingTokenRepository = MockSharingTokenRepository();
+    mockRelationshipScoreService = MockRelationshipScoreService();
     when(mockAuthService.currentUserId).thenReturn('u1');
+    when(mockRelationshipScoreService.computeScore(any, any))
+        .thenAnswer((_) async => stubScore);
     provider = PersonDetailProvider(
       personRepository: mockPersonRepository,
       meetingRepository: mockMeetingRepository,
       authService: mockAuthService,
       sharingTokenRepository: mockSharingTokenRepository,
+      relationshipScoreService: mockRelationshipScoreService,
     );
   });
 
@@ -60,6 +80,15 @@ void main() {
       await provider.initialize(testPerson);
 
       expect(provider.person, equals(testPerson));
+    });
+
+    test('initialize computes and stores relationship score', () async {
+      when(mockMeetingRepository.getMeetingsCountForPerson('u1', 'p1'))
+          .thenAnswer((_) async => 0);
+
+      await provider.initialize(testPerson);
+
+      expect(provider.score, equals(stubScore));
     });
 
     test('updatePerson calls repository and updates _person on success',

--- a/test/presentation/persons/person_detail_provider_test.mocks.dart
+++ b/test/presentation/persons/person_detail_provider_test.mocks.dart
@@ -3,20 +3,22 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i7;
+import 'dart:async' as _i8;
 
-import 'package:firebase_auth/firebase_auth.dart' as _i12;
-import 'package:friendsheet/data/models/meeting.dart' as _i9;
+import 'package:firebase_auth/firebase_auth.dart' as _i13;
+import 'package:friendsheet/data/models/meeting.dart' as _i10;
 import 'package:friendsheet/data/models/person.dart' as _i2;
 import 'package:friendsheet/data/models/sharing_token.dart' as _i3;
-import 'package:friendsheet/data/repositories/cache_invalidator.dart' as _i6;
-import 'package:friendsheet/data/repositories/meeting_repository.dart' as _i8;
-import 'package:friendsheet/data/repositories/person_repository.dart' as _i5;
+import 'package:friendsheet/data/repositories/cache_invalidator.dart' as _i7;
+import 'package:friendsheet/data/repositories/meeting_repository.dart' as _i9;
+import 'package:friendsheet/data/repositories/person_repository.dart' as _i6;
 import 'package:friendsheet/data/repositories/sharing_token_repository.dart'
     as _i4;
-import 'package:friendsheet/data/services/auth_service.dart' as _i11;
+import 'package:friendsheet/data/services/auth_service.dart' as _i12;
+import 'package:friendsheet/data/services/relationship_score_service.dart'
+    as _i5;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i10;
+import 'package:mockito/src/dummies.dart' as _i11;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -63,16 +65,27 @@ class _FakeTokenValidationResult_2 extends _i1.SmartFake
         );
 }
 
+class _FakeRelationshipScore_3 extends _i1.SmartFake
+    implements _i5.RelationshipScore {
+  _FakeRelationshipScore_3(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [PersonRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockPersonRepository extends _i1.Mock implements _i5.PersonRepository {
+class MockPersonRepository extends _i1.Mock implements _i6.PersonRepository {
   MockPersonRepository() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  set cacheInvalidator(_i6.CacheInvalidator? _cacheInvalidator) =>
+  set cacheInvalidator(_i7.CacheInvalidator? _cacheInvalidator) =>
       super.noSuchMethod(
         Invocation.setter(
           #cacheInvalidator,
@@ -82,17 +95,17 @@ class MockPersonRepository extends _i1.Mock implements _i5.PersonRepository {
       );
 
   @override
-  _i7.Future<List<_i2.Person>> getPersonsByUser(String? userId) =>
+  _i8.Future<List<_i2.Person>> getPersonsByUser(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPersonsByUser,
           [userId],
         ),
-        returnValue: _i7.Future<List<_i2.Person>>.value(<_i2.Person>[]),
-      ) as _i7.Future<List<_i2.Person>>);
+        returnValue: _i8.Future<List<_i2.Person>>.value(<_i2.Person>[]),
+      ) as _i8.Future<List<_i2.Person>>);
 
   @override
-  _i7.Future<List<_i2.Person>> getPersonsByIds(
+  _i8.Future<List<_i2.Person>> getPersonsByIds(
     List<String>? ids,
     String? userId,
   ) =>
@@ -104,36 +117,36 @@ class MockPersonRepository extends _i1.Mock implements _i5.PersonRepository {
             userId,
           ],
         ),
-        returnValue: _i7.Future<List<_i2.Person>>.value(<_i2.Person>[]),
-      ) as _i7.Future<List<_i2.Person>>);
+        returnValue: _i8.Future<List<_i2.Person>>.value(<_i2.Person>[]),
+      ) as _i8.Future<List<_i2.Person>>);
 
   @override
-  _i7.Future<_i2.Person> addPerson(_i2.Person? person) => (super.noSuchMethod(
+  _i8.Future<_i2.Person> addPerson(_i2.Person? person) => (super.noSuchMethod(
         Invocation.method(
           #addPerson,
           [person],
         ),
-        returnValue: _i7.Future<_i2.Person>.value(_FakePerson_0(
+        returnValue: _i8.Future<_i2.Person>.value(_FakePerson_0(
           this,
           Invocation.method(
             #addPerson,
             [person],
           ),
         )),
-      ) as _i7.Future<_i2.Person>);
+      ) as _i8.Future<_i2.Person>);
 
   @override
-  _i7.Future<void> updatePerson(_i2.Person? person) => (super.noSuchMethod(
+  _i8.Future<void> updatePerson(_i2.Person? person) => (super.noSuchMethod(
         Invocation.method(
           #updatePerson,
           [person],
         ),
-        returnValue: _i7.Future<void>.value(),
-        returnValueForMissingStub: _i7.Future<void>.value(),
-      ) as _i7.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
 
   @override
-  _i7.Future<bool> isDuplicateName(
+  _i8.Future<bool> isDuplicateName(
     String? userId,
     String? firstName,
     String? lastName, {
@@ -149,11 +162,11 @@ class MockPersonRepository extends _i1.Mock implements _i5.PersonRepository {
           ],
           {#excludeId: excludeId},
         ),
-        returnValue: _i7.Future<bool>.value(false),
-      ) as _i7.Future<bool>);
+        returnValue: _i8.Future<bool>.value(false),
+      ) as _i8.Future<bool>);
 
   @override
-  _i7.Future<void> deletePerson(
+  _i8.Future<void> deletePerson(
     String? userId,
     String? personId,
   ) =>
@@ -165,21 +178,21 @@ class MockPersonRepository extends _i1.Mock implements _i5.PersonRepository {
             personId,
           ],
         ),
-        returnValue: _i7.Future<void>.value(),
-        returnValueForMissingStub: _i7.Future<void>.value(),
-      ) as _i7.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
 }
 
 /// A class which mocks [MeetingRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMeetingRepository extends _i1.Mock implements _i8.MeetingRepository {
+class MockMeetingRepository extends _i1.Mock implements _i9.MeetingRepository {
   MockMeetingRepository() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  set cacheInvalidator(_i6.CacheInvalidator? _cacheInvalidator) =>
+  set cacheInvalidator(_i7.CacheInvalidator? _cacheInvalidator) =>
       super.noSuchMethod(
         Invocation.setter(
           #cacheInvalidator,
@@ -189,52 +202,52 @@ class MockMeetingRepository extends _i1.Mock implements _i8.MeetingRepository {
       );
 
   @override
-  _i7.Future<String> saveMeeting(_i9.Meeting? meeting) => (super.noSuchMethod(
+  _i8.Future<String> saveMeeting(_i10.Meeting? meeting) => (super.noSuchMethod(
         Invocation.method(
           #saveMeeting,
           [meeting],
         ),
-        returnValue: _i7.Future<String>.value(_i10.dummyValue<String>(
+        returnValue: _i8.Future<String>.value(_i11.dummyValue<String>(
           this,
           Invocation.method(
             #saveMeeting,
             [meeting],
           ),
         )),
-      ) as _i7.Future<String>);
+      ) as _i8.Future<String>);
 
   @override
-  _i7.Stream<List<_i9.Meeting>> getMeetingsByUser(String? userId) =>
+  _i8.Stream<List<_i10.Meeting>> getMeetingsByUser(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getMeetingsByUser,
           [userId],
         ),
-        returnValue: _i7.Stream<List<_i9.Meeting>>.empty(),
-      ) as _i7.Stream<List<_i9.Meeting>>);
+        returnValue: _i8.Stream<List<_i10.Meeting>>.empty(),
+      ) as _i8.Stream<List<_i10.Meeting>>);
 
   @override
-  _i7.Future<List<_i9.Meeting>> getAllMeetings(String? userId) =>
+  _i8.Future<List<_i10.Meeting>> getAllMeetings(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getAllMeetings,
           [userId],
         ),
-        returnValue: _i7.Future<List<_i9.Meeting>>.value(<_i9.Meeting>[]),
-      ) as _i7.Future<List<_i9.Meeting>>);
+        returnValue: _i8.Future<List<_i10.Meeting>>.value(<_i10.Meeting>[]),
+      ) as _i8.Future<List<_i10.Meeting>>);
 
   @override
-  _i7.Future<void> updateMeeting(_i9.Meeting? meeting) => (super.noSuchMethod(
+  _i8.Future<void> updateMeeting(_i10.Meeting? meeting) => (super.noSuchMethod(
         Invocation.method(
           #updateMeeting,
           [meeting],
         ),
-        returnValue: _i7.Future<void>.value(),
-        returnValueForMissingStub: _i7.Future<void>.value(),
-      ) as _i7.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
 
   @override
-  _i7.Future<void> deleteMeeting(
+  _i8.Future<void> deleteMeeting(
     String? userId,
     String? meetingId,
   ) =>
@@ -246,12 +259,12 @@ class MockMeetingRepository extends _i1.Mock implements _i8.MeetingRepository {
             meetingId,
           ],
         ),
-        returnValue: _i7.Future<void>.value(),
-        returnValueForMissingStub: _i7.Future<void>.value(),
-      ) as _i7.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
 
   @override
-  _i7.Future<List<_i9.Meeting>> getMeetingsByParticipant(
+  _i8.Future<List<_i10.Meeting>> getMeetingsByParticipant(
     String? userId,
     String? personId,
   ) =>
@@ -263,11 +276,11 @@ class MockMeetingRepository extends _i1.Mock implements _i8.MeetingRepository {
             personId,
           ],
         ),
-        returnValue: _i7.Future<List<_i9.Meeting>>.value(<_i9.Meeting>[]),
-      ) as _i7.Future<List<_i9.Meeting>>);
+        returnValue: _i8.Future<List<_i10.Meeting>>.value(<_i10.Meeting>[]),
+      ) as _i8.Future<List<_i10.Meeting>>);
 
   @override
-  _i7.Future<int> getMeetingsCountForPerson(
+  _i8.Future<int> getMeetingsCountForPerson(
     String? userId,
     String? personId,
   ) =>
@@ -279,11 +292,11 @@ class MockMeetingRepository extends _i1.Mock implements _i8.MeetingRepository {
             personId,
           ],
         ),
-        returnValue: _i7.Future<int>.value(0),
-      ) as _i7.Future<int>);
+        returnValue: _i8.Future<int>.value(0),
+      ) as _i8.Future<int>);
 
   @override
-  _i7.Future<void> replaceCategoryInMeetings(
+  _i8.Future<void> replaceCategoryInMeetings(
     String? userId,
     String? sourceId,
     String? targetId,
@@ -297,12 +310,12 @@ class MockMeetingRepository extends _i1.Mock implements _i8.MeetingRepository {
             targetId,
           ],
         ),
-        returnValue: _i7.Future<void>.value(),
-        returnValueForMissingStub: _i7.Future<void>.value(),
-      ) as _i7.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
 
   @override
-  _i7.Future<_i9.Meeting?> getLastMeetingWithoutNotes(
+  _i8.Future<_i10.Meeting?> getLastMeetingWithoutNotes(
     String? userId,
     DateTime? since,
   ) =>
@@ -314,11 +327,11 @@ class MockMeetingRepository extends _i1.Mock implements _i8.MeetingRepository {
             since,
           ],
         ),
-        returnValue: _i7.Future<_i9.Meeting?>.value(),
-      ) as _i7.Future<_i9.Meeting?>);
+        returnValue: _i8.Future<_i10.Meeting?>.value(),
+      ) as _i8.Future<_i10.Meeting?>);
 
   @override
-  _i7.Future<List<_i9.Meeting>> getRecentMeetingsWithoutNotes(
+  _i8.Future<List<_i10.Meeting>> getRecentMeetingsWithoutNotes(
     String? userId,
     DateTime? since, {
     int? limit = 3,
@@ -332,11 +345,11 @@ class MockMeetingRepository extends _i1.Mock implements _i8.MeetingRepository {
           ],
           {#limit: limit},
         ),
-        returnValue: _i7.Future<List<_i9.Meeting>>.value(<_i9.Meeting>[]),
-      ) as _i7.Future<List<_i9.Meeting>>);
+        returnValue: _i8.Future<List<_i10.Meeting>>.value(<_i10.Meeting>[]),
+      ) as _i8.Future<List<_i10.Meeting>>);
 
   @override
-  _i7.Future<Set<String>> getPersonIdsSeenSince(
+  _i8.Future<Set<String>> getPersonIdsSeenSince(
     String? userId,
     DateTime? since,
   ) =>
@@ -348,11 +361,11 @@ class MockMeetingRepository extends _i1.Mock implements _i8.MeetingRepository {
             since,
           ],
         ),
-        returnValue: _i7.Future<Set<String>>.value(<String>{}),
-      ) as _i7.Future<Set<String>>);
+        returnValue: _i8.Future<Set<String>>.value(<String>{}),
+      ) as _i8.Future<Set<String>>);
 
   @override
-  _i7.Future<List<_i9.Meeting>> getRecentMeetingsByPerson(
+  _i8.Future<List<_i10.Meeting>> getRecentMeetingsByPerson(
     String? userId,
     String? personId, {
     int? limit = 4,
@@ -366,11 +379,11 @@ class MockMeetingRepository extends _i1.Mock implements _i8.MeetingRepository {
           ],
           {#limit: limit},
         ),
-        returnValue: _i7.Future<List<_i9.Meeting>>.value(<_i9.Meeting>[]),
-      ) as _i7.Future<List<_i9.Meeting>>);
+        returnValue: _i8.Future<List<_i10.Meeting>>.value(<_i10.Meeting>[]),
+      ) as _i8.Future<List<_i10.Meeting>>);
 
   @override
-  _i7.Future<void> removePersonFromMeetings(
+  _i8.Future<void> removePersonFromMeetings(
     String? userId,
     String? personId,
   ) =>
@@ -382,64 +395,64 @@ class MockMeetingRepository extends _i1.Mock implements _i8.MeetingRepository {
             personId,
           ],
         ),
-        returnValue: _i7.Future<void>.value(),
-        returnValueForMissingStub: _i7.Future<void>.value(),
-      ) as _i7.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
 }
 
 /// A class which mocks [AuthService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAuthService extends _i1.Mock implements _i11.AuthService {
+class MockAuthService extends _i1.Mock implements _i12.AuthService {
   MockAuthService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i7.Stream<_i12.User?> get authStateChanges => (super.noSuchMethod(
+  _i8.Stream<_i13.User?> get authStateChanges => (super.noSuchMethod(
         Invocation.getter(#authStateChanges),
-        returnValue: _i7.Stream<_i12.User?>.empty(),
-      ) as _i7.Stream<_i12.User?>);
+        returnValue: _i8.Stream<_i13.User?>.empty(),
+      ) as _i8.Stream<_i13.User?>);
 
   @override
-  _i7.Future<_i12.User?> signInWithGoogle() => (super.noSuchMethod(
+  _i8.Future<_i13.User?> signInWithGoogle() => (super.noSuchMethod(
         Invocation.method(
           #signInWithGoogle,
           [],
         ),
-        returnValue: _i7.Future<_i12.User?>.value(),
-      ) as _i7.Future<_i12.User?>);
+        returnValue: _i8.Future<_i13.User?>.value(),
+      ) as _i8.Future<_i13.User?>);
 
   @override
-  _i7.Future<void> signOut() => (super.noSuchMethod(
+  _i8.Future<void> signOut() => (super.noSuchMethod(
         Invocation.method(
           #signOut,
           [],
         ),
-        returnValue: _i7.Future<void>.value(),
-        returnValueForMissingStub: _i7.Future<void>.value(),
-      ) as _i7.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
 
   @override
-  _i7.Future<void> runOnboardingIfNeeded(String? userId) => (super.noSuchMethod(
+  _i8.Future<void> runOnboardingIfNeeded(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #runOnboardingIfNeeded,
           [userId],
         ),
-        returnValue: _i7.Future<void>.value(),
-        returnValueForMissingStub: _i7.Future<void>.value(),
-      ) as _i7.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
 
   @override
-  _i7.Future<void> copyGlobalCategoriesToUserForTest(String? userId) =>
+  _i8.Future<void> copyGlobalCategoriesToUserForTest(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #copyGlobalCategoriesToUserForTest,
           [userId],
         ),
-        returnValue: _i7.Future<void>.value(),
-        returnValueForMissingStub: _i7.Future<void>.value(),
-      ) as _i7.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
 }
 
 /// A class which mocks [SharingTokenRepository].
@@ -452,33 +465,33 @@ class MockSharingTokenRepository extends _i1.Mock
   }
 
   @override
-  _i7.Future<_i3.SharingToken> generateToken(String? userId) =>
+  _i8.Future<_i3.SharingToken> generateToken(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #generateToken,
           [userId],
         ),
-        returnValue: _i7.Future<_i3.SharingToken>.value(_FakeSharingToken_1(
+        returnValue: _i8.Future<_i3.SharingToken>.value(_FakeSharingToken_1(
           this,
           Invocation.method(
             #generateToken,
             [userId],
           ),
         )),
-      ) as _i7.Future<_i3.SharingToken>);
+      ) as _i8.Future<_i3.SharingToken>);
 
   @override
-  _i7.Future<_i3.SharingToken?> getActiveToken(String? userId) =>
+  _i8.Future<_i3.SharingToken?> getActiveToken(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getActiveToken,
           [userId],
         ),
-        returnValue: _i7.Future<_i3.SharingToken?>.value(),
-      ) as _i7.Future<_i3.SharingToken?>);
+        returnValue: _i8.Future<_i3.SharingToken?>.value(),
+      ) as _i8.Future<_i3.SharingToken?>);
 
   @override
-  _i7.Future<void> deleteToken(
+  _i8.Future<void> deleteToken(
     String? userId,
     String? tokenId,
   ) =>
@@ -490,19 +503,19 @@ class MockSharingTokenRepository extends _i1.Mock
             tokenId,
           ],
         ),
-        returnValue: _i7.Future<void>.value(),
-        returnValueForMissingStub: _i7.Future<void>.value(),
-      ) as _i7.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
 
   @override
-  _i7.Future<_i4.TokenValidationResult> validateAndClaimToken(
+  _i8.Future<_i4.TokenValidationResult> validateAndClaimToken(
           String? tokenValue) =>
       (super.noSuchMethod(
         Invocation.method(
           #validateAndClaimToken,
           [tokenValue],
         ),
-        returnValue: _i7.Future<_i4.TokenValidationResult>.value(
+        returnValue: _i8.Future<_i4.TokenValidationResult>.value(
             _FakeTokenValidationResult_2(
           this,
           Invocation.method(
@@ -510,10 +523,10 @@ class MockSharingTokenRepository extends _i1.Mock
             [tokenValue],
           ),
         )),
-      ) as _i7.Future<_i4.TokenValidationResult>);
+      ) as _i8.Future<_i4.TokenValidationResult>);
 
   @override
-  _i7.Future<void> markAsUsed(
+  _i8.Future<void> markAsUsed(
     String? userId,
     String? tokenId,
   ) =>
@@ -525,7 +538,43 @@ class MockSharingTokenRepository extends _i1.Mock
             tokenId,
           ],
         ),
-        returnValue: _i7.Future<void>.value(),
-        returnValueForMissingStub: _i7.Future<void>.value(),
-      ) as _i7.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
+}
+
+/// A class which mocks [RelationshipScoreService].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockRelationshipScoreService extends _i1.Mock
+    implements _i5.RelationshipScoreService {
+  MockRelationshipScoreService() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i8.Future<_i5.RelationshipScore> computeScore(
+    String? userId,
+    String? personId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #computeScore,
+          [
+            userId,
+            personId,
+          ],
+        ),
+        returnValue:
+            _i8.Future<_i5.RelationshipScore>.value(_FakeRelationshipScore_3(
+          this,
+          Invocation.method(
+            #computeScore,
+            [
+              userId,
+              personId,
+            ],
+          ),
+        )),
+      ) as _i8.Future<_i5.RelationshipScore>);
 }

--- a/test/presentation/persons/relationship_strength_widget_test.dart
+++ b/test/presentation/persons/relationship_strength_widget_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:friendsheet/data/services/relationship_score_service.dart';
+import 'package:friendsheet/presentation/persons/relationship_strength_widget.dart';
+
+void main() {
+  Widget buildWidget(RelationshipScore score) => MaterialApp(
+        home: Scaffold(body: RelationshipStrengthWidget(score: score)),
+      );
+
+  // ---------------------------------------------------------------------------
+  // RelationshipStrengthWidget
+  // ---------------------------------------------------------------------------
+
+  group('RelationshipStrengthWidget', () {
+    testWidgets('renders score, label, title and progress bar', (tester) async {
+      const score = RelationshipScore(
+        score: 55,
+        label: 'Good',
+        meetingsIn2y: 10,
+        daysSinceLast: 30,
+        distinctCategories2y: 3,
+        distinctWeights2y: 2,
+      );
+
+      await tester.pumpWidget(buildWidget(score));
+
+      expect(find.text('Relationship Strength'), findsOneWidget);
+      expect(find.text('55/100'), findsOneWidget);
+      expect(find.text('Good'), findsOneWidget);
+      expect(find.byType(LinearProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('progress bar value equals score/100', (tester) async {
+      const score = RelationshipScore(
+        score: 75,
+        label: 'Strong',
+        meetingsIn2y: 20,
+        daysSinceLast: 14,
+        distinctCategories2y: 5,
+        distinctWeights2y: 3,
+      );
+
+      await tester.pumpWidget(buildWidget(score));
+
+      final indicator = tester.widget<LinearProgressIndicator>(
+        find.byType(LinearProgressIndicator),
+      );
+      expect(indicator.value, closeTo(0.75, 0.001));
+    });
+
+    testWidgets('bar color is green for score >= 80', (tester) async {
+      const score = RelationshipScore(
+        score: 85,
+        label: 'Very close',
+        meetingsIn2y: 40,
+        daysSinceLast: 2,
+        distinctCategories2y: 9,
+        distinctWeights2y: 3,
+      );
+
+      await tester.pumpWidget(buildWidget(score));
+
+      final indicator = tester.widget<LinearProgressIndicator>(
+        find.byType(LinearProgressIndicator),
+      );
+      expect(indicator.color, Colors.green);
+    });
+
+    testWidgets('bar color is red for score < 20', (tester) async {
+      const score = RelationshipScore(
+        score: 10,
+        label: 'Distant',
+        meetingsIn2y: 0,
+        daysSinceLast: 400,
+        distinctCategories2y: 0,
+        distinctWeights2y: 0,
+      );
+
+      await tester.pumpWidget(buildWidget(score));
+
+      final indicator = tester.widget<LinearProgressIndicator>(
+        find.byType(LinearProgressIndicator),
+      );
+      expect(indicator.color, Colors.red);
+    });
+  });
+}

--- a/test/presentation/providers/ai_chat_provider_test.dart
+++ b/test/presentation/providers/ai_chat_provider_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:friendsheet/data/models/ai_exceptions.dart';
 import 'package:friendsheet/data/models/buddy_context.dart';
@@ -5,16 +7,24 @@ import 'package:friendsheet/data/models/meeting.dart';
 import 'package:friendsheet/data/models/person.dart';
 import 'package:friendsheet/data/services/buddy_write_service.dart';
 import 'package:friendsheet/data/services/context_builder_service.dart';
+import 'package:friendsheet/data/services/local_cache_service.dart';
 import 'package:friendsheet/data/services/open_ai_service.dart';
 import 'package:friendsheet/data/services/relationship_score_service.dart';
 import 'package:friendsheet/presentation/ai_chat/ai_chat_provider.dart';
 import 'package:friendsheet/presentation/ai_chat/buddy_chat_mode.dart';
+import 'package:friendsheet/services/hive_service.dart';
+import 'package:hive/hive.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 
 import 'ai_chat_provider_test.mocks.dart';
 
-@GenerateMocks([OpenAIService, ContextBuilderService, BuddyWriteService, RelationshipScoreService])
+@GenerateMocks([
+  OpenAIService,
+  ContextBuilderService,
+  BuddyWriteService,
+  RelationshipScoreService
+])
 void main() {
   late MockOpenAIService mockOpenAI;
   late MockContextBuilderService mockContextBuilder;
@@ -1031,6 +1041,117 @@ void main() {
       expect(reply, contains('Anna'));
       // No leftover pseudonym fragments
       expect(reply, isNot(contains('Friend_')));
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // sendMessage — person disambiguation
+  // ---------------------------------------------------------------------------
+
+  group('sendMessage — person disambiguation', () {
+    late Directory tempDir;
+
+    final annaK = Person(
+      id: 'p1',
+      userId: 'user-1',
+      firstName: 'Anna',
+      lastName: 'Kowalska',
+      createdAt: DateTime(2026, 1, 1),
+    );
+    final annaN = Person(
+      id: 'p2',
+      userId: 'user-1',
+      firstName: 'Anna',
+      lastName: 'Nowak',
+      createdAt: DateTime(2026, 1, 1),
+    );
+
+    const ambigCtx = BuddyContext(
+      meetings: [],
+      persons: [],
+      pseudonymToRealName: {
+        'Friend_A': 'Anna Kowalska',
+        'Friend_B': 'Anna Nowak',
+      },
+      personIdToPseudonym: {'p1': 'Friend_A', 'p2': 'Friend_B'},
+    );
+
+    const stubScore = RelationshipScore(
+      score: 55,
+      label: 'Good',
+      meetingsIn2y: 10,
+      daysSinceLast: 30,
+      distinctCategories2y: 3,
+      distinctWeights2y: 2,
+    );
+
+    setUpAll(() async {
+      tempDir = await Directory.systemTemp.createTemp('hive_disamb_test_');
+      await HiveService.initialize(testPath: tempDir.path);
+    });
+
+    tearDownAll(() async {
+      await Hive.close();
+      await tempDir.delete(recursive: true);
+    });
+
+    setUp(() async {
+      await HiveService.clearUserData('user-1');
+      when(mockContextBuilder.buildFullContext(any))
+          .thenAnswer((_) async => ambigCtx);
+      when(mockContextBuilder.findMostRecentMeetingWithoutNotes(any))
+          .thenAnswer((_) async => null);
+      when(mockRelationshipScore.computeScore(any, any))
+          .thenAnswer((_) async => stubScore);
+      await provider.initialize('user-1');
+    });
+
+    test(
+        '2 persons match → disambiguation message + 2 action buttons, no AI call',
+        () async {
+      await LocalCacheService().upsertPerson('user-1', annaK);
+      await LocalCacheService().upsertPerson('user-1', annaN);
+
+      await provider.sendMessage('Why is Anna score 57?');
+
+      // [greeting, user message, disambiguation assistant message]
+      expect(provider.messages.length, 3);
+      expect(provider.messages[2].role, 'assistant');
+      expect(
+          provider.messages[2].content, contains("I'm not sure who you mean"));
+      expect(provider.isLoading, isFalse);
+      expect(provider.pendingActions, hasLength(2));
+      expect(
+          provider.pendingActions!
+              .any((a) => a.actionId == 'disambiguate_person:p1'),
+          isTrue);
+      expect(
+          provider.pendingActions!
+              .any((a) => a.actionId == 'disambiguate_person:p2'),
+          isTrue);
+      verifyNever(mockOpenAI.sendMessage(any, any, any));
+    });
+
+    test('disambiguate_person action sends pseudonymized text to AI', () async {
+      await LocalCacheService().upsertPerson('user-1', annaK);
+      await LocalCacheService().upsertPerson('user-1', annaN);
+      when(mockContextBuilder.serializeToPromptWithScores(any, any,
+              includeNotes: anyNamed('includeNotes')))
+          .thenAnswer((_) async => 'context');
+      when(mockOpenAI.sendMessage(any, any, any))
+          .thenAnswer((_) => Stream.value('Friend_A has score 55'));
+
+      await provider.sendMessage('Why is Anna score 57?');
+
+      // User selects Anna Kowalska — AI response translates Friend_A → Anna Kowalska.
+      await provider.handleAction(const BuddyAction(
+        label: 'Anna Kowalska — score 55/100',
+        actionId: 'disambiguate_person:p1',
+      ));
+
+      expect(provider.isLoading, isFalse);
+      expect(provider.messages.last.role, 'assistant');
+      expect(provider.messages.last.content, contains('Anna Kowalska'));
     });
   });
 }

--- a/test/presentation/providers/ai_chat_provider_test.dart
+++ b/test/presentation/providers/ai_chat_provider_test.dart
@@ -6,6 +6,7 @@ import 'package:friendsheet/data/models/person.dart';
 import 'package:friendsheet/data/services/buddy_write_service.dart';
 import 'package:friendsheet/data/services/context_builder_service.dart';
 import 'package:friendsheet/data/services/open_ai_service.dart';
+import 'package:friendsheet/data/services/relationship_score_service.dart';
 import 'package:friendsheet/presentation/ai_chat/ai_chat_provider.dart';
 import 'package:friendsheet/presentation/ai_chat/buddy_chat_mode.dart';
 import 'package:mockito/annotations.dart';
@@ -13,11 +14,12 @@ import 'package:mockito/mockito.dart';
 
 import 'ai_chat_provider_test.mocks.dart';
 
-@GenerateMocks([OpenAIService, ContextBuilderService, BuddyWriteService])
+@GenerateMocks([OpenAIService, ContextBuilderService, BuddyWriteService, RelationshipScoreService])
 void main() {
   late MockOpenAIService mockOpenAI;
   late MockContextBuilderService mockContextBuilder;
   late MockBuddyWriteService mockBuddyWrite;
+  late MockRelationshipScoreService mockRelationshipScore;
   late AIChatProvider provider;
 
   final now = DateTime(2026, 3, 10);
@@ -51,11 +53,13 @@ void main() {
     mockOpenAI = MockOpenAIService();
     mockContextBuilder = MockContextBuilderService();
     mockBuddyWrite = MockBuddyWriteService();
+    mockRelationshipScore = MockRelationshipScoreService();
 
     provider = AIChatProvider(
       openAIService: mockOpenAI,
       contextBuilderService: mockContextBuilder,
       buddyWriteService: mockBuddyWrite,
+      relationshipScoreService: mockRelationshipScore,
     );
   });
 
@@ -163,6 +167,9 @@ void main() {
       when(mockContextBuilder.serializeToPrompt(any,
               includeNotes: anyNamed('includeNotes')))
           .thenReturn('## Social Context\n');
+      when(mockContextBuilder.serializeToPromptWithScores(any, any,
+              includeNotes: anyNamed('includeNotes')))
+          .thenAnswer((_) async => '## Social Context\n');
       await provider.initialize('user-1');
     });
 
@@ -195,6 +202,9 @@ void main() {
       when(mockContextBuilder.serializeToPrompt(any,
               includeNotes: anyNamed('includeNotes')))
           .thenReturn('context');
+      when(mockContextBuilder.serializeToPromptWithScores(any, any,
+              includeNotes: anyNamed('includeNotes')))
+          .thenAnswer((_) async => 'context');
       when(mockContextBuilder.findMostRecentMeetingWithoutNotes(any))
           .thenAnswer((_) async => null);
 
@@ -203,6 +213,7 @@ void main() {
         openAIService: mockOpenAI,
         contextBuilderService: mockContextBuilder,
         buddyWriteService: mockBuddyWrite,
+        relationshipScoreService: mockRelationshipScore,
       );
       await providerWithMapping.initialize('user-1');
 
@@ -267,6 +278,9 @@ void main() {
       when(mockContextBuilder.serializeToPrompt(any,
               includeNotes: anyNamed('includeNotes')))
           .thenReturn('context');
+      when(mockContextBuilder.serializeToPromptWithScores(any, any,
+              includeNotes: anyNamed('includeNotes')))
+          .thenAnswer((_) async => 'context');
       await provider.initialize('user-1');
     });
 
@@ -697,6 +711,9 @@ void main() {
       when(mockContextBuilder.serializeToPrompt(any,
               includeNotes: anyNamed('includeNotes')))
           .thenReturn('context');
+      when(mockContextBuilder.serializeToPromptWithScores(any, any,
+              includeNotes: anyNamed('includeNotes')))
+          .thenAnswer((_) async => 'context');
       when(mockOpenAI.sendMessage(any, any, any))
           .thenAnswer((_) => Stream.value('Great memories with Marco!'));
 
@@ -955,6 +972,9 @@ void main() {
       when(mockContextBuilder.serializeToPrompt(any,
               includeNotes: anyNamed('includeNotes')))
           .thenReturn('context');
+      when(mockContextBuilder.serializeToPromptWithScores(any, any,
+              includeNotes: anyNamed('includeNotes')))
+          .thenAnswer((_) async => 'context');
       when(mockOpenAI.sendMessage(any, any, any))
           .thenAnswer((_) => Stream.value('Hi!'));
 
@@ -986,6 +1006,9 @@ void main() {
       when(mockContextBuilder.serializeToPrompt(any,
               includeNotes: anyNamed('includeNotes')))
           .thenReturn('context');
+      when(mockContextBuilder.serializeToPromptWithScores(any, any,
+              includeNotes: anyNamed('includeNotes')))
+          .thenAnswer((_) async => 'context');
       when(mockContextBuilder.findMostRecentMeetingWithoutNotes(any))
           .thenAnswer((_) async => null);
 
@@ -993,6 +1016,7 @@ void main() {
         openAIService: mockOpenAI,
         contextBuilderService: mockContextBuilder,
         buddyWriteService: mockBuddyWrite,
+        relationshipScoreService: mockRelationshipScore,
       );
       await p.initialize('user-1');
 

--- a/test/presentation/providers/ai_chat_provider_test.mocks.dart
+++ b/test/presentation/providers/ai_chat_provider_test.mocks.dart
@@ -3,16 +3,18 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i4;
+import 'dart:async' as _i5;
 
 import 'package:friendsheet/data/models/buddy_context.dart' as _i2;
-import 'package:friendsheet/data/models/chat_message.dart' as _i5;
-import 'package:friendsheet/data/models/meeting.dart' as _i8;
-import 'package:friendsheet/data/services/buddy_write_service.dart' as _i9;
-import 'package:friendsheet/data/services/context_builder_service.dart' as _i6;
-import 'package:friendsheet/data/services/open_ai_service.dart' as _i3;
+import 'package:friendsheet/data/models/chat_message.dart' as _i6;
+import 'package:friendsheet/data/models/meeting.dart' as _i9;
+import 'package:friendsheet/data/services/buddy_write_service.dart' as _i10;
+import 'package:friendsheet/data/services/context_builder_service.dart' as _i7;
+import 'package:friendsheet/data/services/open_ai_service.dart' as _i4;
+import 'package:friendsheet/data/services/relationship_score_service.dart'
+    as _i3;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i7;
+import 'package:mockito/src/dummies.dart' as _i8;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -38,18 +40,29 @@ class _FakeBuddyContext_0 extends _i1.SmartFake implements _i2.BuddyContext {
         );
 }
 
+class _FakeRelationshipScore_1 extends _i1.SmartFake
+    implements _i3.RelationshipScore {
+  _FakeRelationshipScore_1(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [OpenAIService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockOpenAIService extends _i1.Mock implements _i3.OpenAIService {
+class MockOpenAIService extends _i1.Mock implements _i4.OpenAIService {
   MockOpenAIService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i4.Stream<String> sendMessage(
+  _i5.Stream<String> sendMessage(
     String? contextPrompt,
-    List<_i5.ChatMessage>? history,
+    List<_i6.ChatMessage>? history,
     String? userMessage,
   ) =>
       (super.noSuchMethod(
@@ -61,21 +74,21 @@ class MockOpenAIService extends _i1.Mock implements _i3.OpenAIService {
             userMessage,
           ],
         ),
-        returnValue: _i4.Stream<String>.empty(),
-      ) as _i4.Stream<String>);
+        returnValue: _i5.Stream<String>.empty(),
+      ) as _i5.Stream<String>);
 }
 
 /// A class which mocks [ContextBuilderService].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockContextBuilderService extends _i1.Mock
-    implements _i6.ContextBuilderService {
+    implements _i7.ContextBuilderService {
   MockContextBuilderService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i4.Future<_i2.BuddyContext> buildFullContext(
+  _i5.Future<_i2.BuddyContext> buildFullContext(
     String? userId, {
     DateTime? from,
   }) =>
@@ -85,7 +98,7 @@ class MockContextBuilderService extends _i1.Mock
           [userId],
           {#from: from},
         ),
-        returnValue: _i4.Future<_i2.BuddyContext>.value(_FakeBuddyContext_0(
+        returnValue: _i5.Future<_i2.BuddyContext>.value(_FakeBuddyContext_0(
           this,
           Invocation.method(
             #buildFullContext,
@@ -93,10 +106,10 @@ class MockContextBuilderService extends _i1.Mock
             {#from: from},
           ),
         )),
-      ) as _i4.Future<_i2.BuddyContext>);
+      ) as _i5.Future<_i2.BuddyContext>);
 
   @override
-  _i4.Future<_i2.BuddyContext> buildPersonContext(
+  _i5.Future<_i2.BuddyContext> buildPersonContext(
     String? userId,
     String? personId,
   ) =>
@@ -108,7 +121,7 @@ class MockContextBuilderService extends _i1.Mock
             personId,
           ],
         ),
-        returnValue: _i4.Future<_i2.BuddyContext>.value(_FakeBuddyContext_0(
+        returnValue: _i5.Future<_i2.BuddyContext>.value(_FakeBuddyContext_0(
           this,
           Invocation.method(
             #buildPersonContext,
@@ -118,10 +131,10 @@ class MockContextBuilderService extends _i1.Mock
             ],
           ),
         )),
-      ) as _i4.Future<_i2.BuddyContext>);
+      ) as _i5.Future<_i2.BuddyContext>);
 
   @override
-  _i4.Future<_i2.BuddyContext> buildBirthdayContext(
+  _i5.Future<_i2.BuddyContext> buildBirthdayContext(
     String? userId,
     String? personId,
   ) =>
@@ -133,7 +146,7 @@ class MockContextBuilderService extends _i1.Mock
             personId,
           ],
         ),
-        returnValue: _i4.Future<_i2.BuddyContext>.value(_FakeBuddyContext_0(
+        returnValue: _i5.Future<_i2.BuddyContext>.value(_FakeBuddyContext_0(
           this,
           Invocation.method(
             #buildBirthdayContext,
@@ -143,10 +156,10 @@ class MockContextBuilderService extends _i1.Mock
             ],
           ),
         )),
-      ) as _i4.Future<_i2.BuddyContext>);
+      ) as _i5.Future<_i2.BuddyContext>);
 
   @override
-  _i4.Future<_i2.BuddyContext> buildLapsedFriendContext(
+  _i5.Future<_i2.BuddyContext> buildLapsedFriendContext(
     String? userId,
     String? personId, {
     int? limit = 4,
@@ -160,7 +173,7 @@ class MockContextBuilderService extends _i1.Mock
           ],
           {#limit: limit},
         ),
-        returnValue: _i4.Future<_i2.BuddyContext>.value(_FakeBuddyContext_0(
+        returnValue: _i5.Future<_i2.BuddyContext>.value(_FakeBuddyContext_0(
           this,
           Invocation.method(
             #buildLapsedFriendContext,
@@ -171,7 +184,7 @@ class MockContextBuilderService extends _i1.Mock
             {#limit: limit},
           ),
         )),
-      ) as _i4.Future<_i2.BuddyContext>);
+      ) as _i5.Future<_i2.BuddyContext>);
 
   @override
   String serializeToPrompt(
@@ -184,7 +197,7 @@ class MockContextBuilderService extends _i1.Mock
           [context],
           {#includeNotes: includeNotes},
         ),
-        returnValue: _i7.dummyValue<String>(
+        returnValue: _i8.dummyValue<String>(
           this,
           Invocation.method(
             #serializeToPrompt,
@@ -195,7 +208,35 @@ class MockContextBuilderService extends _i1.Mock
       ) as String);
 
   @override
-  _i4.Future<_i8.Meeting?> getMeetingById(
+  _i5.Future<String> serializeToPromptWithScores(
+    _i2.BuddyContext? context,
+    String? userId, {
+    bool? includeNotes = false,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #serializeToPromptWithScores,
+          [
+            context,
+            userId,
+          ],
+          {#includeNotes: includeNotes},
+        ),
+        returnValue: _i5.Future<String>.value(_i8.dummyValue<String>(
+          this,
+          Invocation.method(
+            #serializeToPromptWithScores,
+            [
+              context,
+              userId,
+            ],
+            {#includeNotes: includeNotes},
+          ),
+        )),
+      ) as _i5.Future<String>);
+
+  @override
+  _i5.Future<_i9.Meeting?> getMeetingById(
     String? userId,
     String? meetingId,
   ) =>
@@ -207,11 +248,11 @@ class MockContextBuilderService extends _i1.Mock
             meetingId,
           ],
         ),
-        returnValue: _i4.Future<_i8.Meeting?>.value(),
-      ) as _i4.Future<_i8.Meeting?>);
+        returnValue: _i5.Future<_i9.Meeting?>.value(),
+      ) as _i5.Future<_i9.Meeting?>);
 
   @override
-  _i4.Future<_i8.Meeting?> findMostRecentMeetingWithoutNotes(
+  _i5.Future<_i9.Meeting?> findMostRecentMeetingWithoutNotes(
     String? userId, {
     int? withinDays = 30,
   }) =>
@@ -221,20 +262,20 @@ class MockContextBuilderService extends _i1.Mock
           [userId],
           {#withinDays: withinDays},
         ),
-        returnValue: _i4.Future<_i8.Meeting?>.value(),
-      ) as _i4.Future<_i8.Meeting?>);
+        returnValue: _i5.Future<_i9.Meeting?>.value(),
+      ) as _i5.Future<_i9.Meeting?>);
 }
 
 /// A class which mocks [BuddyWriteService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockBuddyWriteService extends _i1.Mock implements _i9.BuddyWriteService {
+class MockBuddyWriteService extends _i1.Mock implements _i10.BuddyWriteService {
   MockBuddyWriteService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i4.Future<void> saveNotes(
+  _i5.Future<void> saveNotes(
     String? userId,
     String? meetingId,
     List<String>? notes,
@@ -248,7 +289,43 @@ class MockBuddyWriteService extends _i1.Mock implements _i9.BuddyWriteService {
             notes,
           ],
         ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+}
+
+/// A class which mocks [RelationshipScoreService].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockRelationshipScoreService extends _i1.Mock
+    implements _i3.RelationshipScoreService {
+  MockRelationshipScoreService() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i5.Future<_i3.RelationshipScore> computeScore(
+    String? userId,
+    String? personId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #computeScore,
+          [
+            userId,
+            personId,
+          ],
+        ),
+        returnValue:
+            _i5.Future<_i3.RelationshipScore>.value(_FakeRelationshipScore_1(
+          this,
+          Invocation.method(
+            #computeScore,
+            [
+              userId,
+              personId,
+            ],
+          ),
+        )),
+      ) as _i5.Future<_i3.RelationshipScore>);
 }


### PR DESCRIPTION
## US-107: Relationship Strength Indicator

**As a** user **I want to** see a strength score for each friendship **so that** I can understand at a glance which relationships need more attention

### Changes
- `RelationshipScoreService` — local 0–100 score (frequency 35%, recency 30%, category variety 20%, weight variety 15%) from Hive cache
- `RelationshipStrengthWidget` — colored progress bar on PersonDetailScreen
- `serializeToPromptWithScores` — Buddy can explain scores with partial breakdown
- Smart person name disambiguation — substring match, auto-pseudonymize or show buttons with scores
- 13 new unit/widget tests (895 total)

Closes #262
