### PR TITLE
300 us 123 couple separation flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to Friendsheet are documented here.
 
 ---
 
+### v4.5.10 — US-123: Couple Separation Flow (April 17, 2026)
+- ✅ `lib/data/repositories/person_repository.dart` (MODIFIED) — `unlinkPartner(userId, personId, partnerId)`: batch write clears `partnerId` + `partnerLinkedAt` on both persons via `FieldValue.delete()`, re-fetches and upserts both to Hive
+- ✅ `lib/data/repositories/catch_up_topic_repository.dart` (MODIFIED) — `TopicRedistributionDecision` enum (personA / shared / personB / delete); `applyRedistribution()`: loads partner's active topics, matches by case-insensitive text trim, executes per-topic delete/keep decisions
+- ✅ `lib/presentation/persons/couple_separation_dialog.dart` (NEW) — `CoupleSeparationDialog` StatefulWidget: `AlertDialog` with `SingleChildScrollView + Column` (no ListView); 4-state `ToggleButtons` per topic; all decisions default to `shared`; returns `Map<String, TopicRedistributionDecision>` or null on cancel
+- ✅ `lib/presentation/persons/couple_link_section.dart` (MODIFIED) — added `onUnlinkTap: VoidCallback?`; shows "Unlink" `TextButton` in trailing when linked; tile tap disabled when linked
+- ✅ `lib/presentation/persons/person_detail_provider.dart` (MODIFIED) — `clearPartner()`: clears `partnerId` + `partnerLinkedAt` via `copyWith` for immediate post-separation UI refresh
+- ✅ `lib/presentation/persons/person_detail_screen.dart` (MODIFIED) — `_showSeparationFlow()`: confirmation → load both sides' topics → compute pre-link text sets → redistribution dialog (post-link topics only) → `applyRedistribution()` → auto-delete merged pre-link copies on both sides → `unlinkPartner()` + `clearPartner()` + reload; `_deleteTopic()` now fire-and-forget propagates deletion to partner; `_deletePartnerTopicByText()` helper
+- ✅ `lib/presentation/persons/catch_up_list_section.dart` (MODIFIED) — green badge counter (topic count) added to `ExpansionTile` trailing row, matching child activities style
+- ✅ `lib/presentation/persons/history_section.dart` (MODIFIED) — green badge counter (archived count) added to title row; `Text('Historia')` kept as standalone widget for test compatibility
+- ✅ `test/data/repositories/person_repository_test.dart` (MODIFIED) — 2 new tests: `unlinkPartner` clears fields on both persons, does not affect third person
+- ✅ `test/data/repositories/catch_up_topic_repository_test.dart` (MODIFIED) — 6 new tests: all 4 `applyRedistribution` decisions + default-to-shared + no-op when no partner match
+- ✅ `test/presentation/persons/person_detail_provider_test.dart` (MODIFIED) — 2 new tests: `clearPartner` clears fields, no-op when person null
+- ✅ `test/presentation/persons/couple_link_section_test.dart` (MODIFIED) — 3 new tests: Unlink shown when linked, hidden when unlinked, `onUnlinkTap` fires
+- ✅ `test/presentation/persons/couple_separation_dialog_test.dart` (NEW) — 7 widget tests: title, topic text, 4 ToggleButtons options, cancel returns null, confirm returns decisions map, option selection updates decision, empty topics = no ToggleButtons
+- ✅ `test/presentation/persons/catch_up_list_section_test.dart` (NEW) — 8 widget tests: title, add icon, onAddTap, badge visible with topics, badge absent when empty, topic text expanded, no-topics state, loading indicator
+- ✅ `test/presentation/persons/history_section_test.dart` (MODIFIED) — 2 new tests: badge shows count, badge absent when empty
+- ✅ 983 Flutter tests passing (+30 new tests)
+
+---
+
 ### v4.5.9 — US-122: Couple Link (April 16, 2026)
 - ✅ `lib/data/models/person.dart` (MODIFIED) — added `partnerId: String?` and `partnerLinkedAt: DateTime?` Freezed fields; `fromFirestore` reads both with null-safe fallbacks; `toFirestore` conditionally writes both
 - ✅ `lib/data/models/person.freezed.dart` + `person.g.dart` (REGENERATED) — build_runner output for new fields

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ flutter format --set-exit-if-changed .
 
 **Current Test Status:**
 ```
-✅ All tests passing (953)
+✅ All tests passing (983)
 ✅ Code formatted correctly
 ✅ Firebase connected successfully
 ✅ CI/CD pipeline operational
@@ -174,15 +174,15 @@ Project Link: [https://github.com/aleksanderginalski/Friendsheet-App](https://gi
 
 Full version history is available in [CHANGELOG.md](CHANGELOG.md).
 
-### Latest: v4.5.9 — US-122: Couple Link (April 16, 2026)
-- ✅ `Person` model (MODIFIED): `partnerId: String?` + `partnerLinkedAt: DateTime?`; Freezed regenerated
-- ✅ `PersonRepository` (MODIFIED): `linkPartner()` batch-writes both persons in Firestore + Hive write-through
-- ✅ `CatchUpTopicRepository` (MODIFIED): `mergeTopics()` copies missing topics bidirectionally with case-insensitive deduplication
-- ✅ `CoupleLinkSection` widget (NEW): shows "Link as couple" / "Coupled with [name]" based on link state
-- ✅ `PersonDetailProvider` (MODIFIED): `setPartner()` for immediate post-link UI refresh
-- ✅ `PersonDetailScreen` (MODIFIED): `while(true)` picker→merge flow; topic + archive propagation to partner (fire-and-forget)
-- ✅ `CatchUpListSection` (MODIFIED): converted to `ExpansionTile` (collapsed by default); Add button in header
-- ✅ 16 new tests (953 total)
+### Latest: v4.5.10 — US-123: Couple Separation Flow (April 17, 2026)
+- ✅ `PersonRepository` (MODIFIED): `unlinkPartner()` batch-clears `partnerId`/`partnerLinkedAt` on both persons via `FieldValue.delete()` + Hive write-through
+- ✅ `CatchUpTopicRepository` (MODIFIED): `TopicRedistributionDecision` enum; `applyRedistribution()` applies per-topic personA/shared/personB/delete decisions
+- ✅ `CoupleSeparationDialog` widget (NEW): 4-state `ToggleButtons` per post-link topic; defaults to shared; returns decisions map or null
+- ✅ `CoupleLinkSection` (MODIFIED): added `onUnlinkTap` callback; Unlink button in trailing when linked
+- ✅ `PersonDetailProvider` (MODIFIED): `clearPartner()` for immediate post-separation UI refresh
+- ✅ `PersonDetailScreen` (MODIFIED): full separation flow with pre-link text-set filtering, redistribution dialog, partner copy cleanup, delete propagation
+- ✅ `CatchUpListSection` + `HistorySection` (MODIFIED): green badge counters matching child activities style
+- ✅ 30 new tests (983 total)
 
 See [CHANGELOG.md](CHANGELOG.md) for all previous versions.
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -4752,27 +4752,27 @@ Firestore SDK on Flutter mobile has built-in offline persistence enabled by defa
 **Story Points:** 8
 **Priority:** P3
 **Labels:** `social`, `persons`, `social-graph`
-**Status:** 🔄 In Progress
+**Status:** ✅ Completed
 **Feature:** FEATURE-031: Social Graph — Couple/Family Link
 
 **Acceptance Criteria:**
-- [ ] On Person detail screen, the couple link section has an "Unlink" option
-- [ ] Topics created BEFORE `partnerLinkedAt` → automatically returned to their original individual owner
-- [ ] Topics created AFTER `partnerLinkedAt` → redistribution dialog shown per topic
-- [ ] Redistribution dialog: 4-option switch per topic: `[Person A] | [Shared — copy] | [Person B] | [Delete]`
+- [x] On Person detail screen, the couple link section has an "Unlink" option
+- [x] Topics created BEFORE `partnerLinkedAt` → automatically returned to their original individual owner
+- [x] Topics created AFTER `partnerLinkedAt` → redistribution dialog shown per topic
+- [x] Redistribution dialog: 4-option switch per topic: `[Person A] | [Shared — copy] | [Person B] | [Delete]`
   - Person A → assigned only to Person A
   - Shared → kept as copy on both
   - Person B → assigned only to Person B
   - Delete → permanently removed
-- [ ] After redistribution: `partnerId` and `partnerLinkedAt` cleared on both persons in Firestore + Hive
-- [ ] `flutter analyze` clean, `flutter test` pass
+- [x] After redistribution: `partnerId` and `partnerLinkedAt` cleared on both persons in Firestore + Hive
+- [x] `flutter analyze` clean, `flutter test` pass
 
 **Tasks:**
-- [ ] **TASK-123.1:** Implement `unlinkPartner()` in `PersonRepository` (clear `partnerId` + `partnerLinkedAt` on both persons in Firestore + Hive) — 1h
-- [ ] **TASK-123.2:** Implement topic split logic: filter topics by `createdAt` vs `partnerLinkedAt` to determine auto-return vs dialog topics — 1.5h
-- [ ] **TASK-123.3:** Build redistribution dialog — scrollable list of topics, 4-state switch per item — 3h
-- [ ] **TASK-123.4:** Apply redistribution decisions (move/copy/delete in Firestore + Hive) — 2h
-- [ ] **TASK-123.5:** Trigger redistribution flow on "Unlink" confirmation — 0.5h
+- [x] **TASK-123.1:** Implement `unlinkPartner()` in `PersonRepository` (clear `partnerId` + `partnerLinkedAt` on both persons in Firestore + Hive) — 1h
+- [x] **TASK-123.2:** Implement topic split logic: filter topics by `createdAt` vs `partnerLinkedAt` to determine auto-return vs dialog topics — 1.5h
+- [x] **TASK-123.3:** Build redistribution dialog — scrollable list of topics, 4-state switch per item — 3h
+- [x] **TASK-123.4:** Apply redistribution decisions (move/copy/delete in Firestore + Hive) — 2h
+- [x] **TASK-123.5:** Trigger redistribution flow on "Unlink" confirmation — 0.5h
 
 **Dependencies:** US-122
 **Blocks:** None

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -72,7 +72,8 @@ EPIC-007: Friendsheet M7 - AI Assistant (Buddy)
 EPIC-010: Friendsheet M8 — Social Intelligence & Friends-Quest
 ├── FEATURE-030: Catch-up Topics
 ├── FEATURE-031: Social Graph — Couple/Family Link
-└── FEATURE-032: Friends-Quest
+├── FEATURE-032: Friends-Quest
+└── FEATURE-033: Person Recognition — Bonus Points
 ```
 
 
@@ -4751,7 +4752,7 @@ Firestore SDK on Flutter mobile has built-in offline persistence enabled by defa
 **Story Points:** 8
 **Priority:** P3
 **Labels:** `social`, `persons`, `social-graph`
-**Status:** 📋 Planned
+**Status:** 🔄 In Progress
 **Feature:** FEATURE-031: Social Graph — Couple/Family Link
 
 **Acceptance Criteria:**
@@ -5023,6 +5024,85 @@ Firestore SDK on Flutter mobile has built-in offline persistence enabled by defa
 - [ ] **TASK-129.5:** Extend `serializeToPromptWithScores` to append effective settings section per person — 1h
 
 **Dependencies:** US-128
+**Blocks:** None
+
+---
+
+## 🏅 FEATURE-033: Person Recognition — Bonus Points
+
+**Description:** Allow users to award bonus points (1–3) with a comment to individual meeting participants who did something exceptional. Bonuses stack per person per meeting and are factored into relationship statistics.
+**Priority:** P2
+**Role:** Developer
+**Status:** 📋 Planned
+
+---
+
+### US-130: Person Bonus — Model, UI & Meeting Notes
+
+**As a** user
+**I want to** award bonus points with a comment to a specific participant after a meeting
+**So that** I can recognise extraordinary contributions and have them reflected in my notes
+
+**Story Points:** 8
+**Priority:** P2
+**Labels:** `persons`, `meetings`, `model`
+**Status:** 📋 Planned
+**Feature:** FEATURE-033: Person Recognition — Bonus Points
+
+**Acceptance Criteria:**
+- [ ] New Freezed model `PersonBonus` with fields: `points` (int, 1–3), `comment` (String)
+- [ ] `Meeting` model gains field `personBonuses: Map<String, List<PersonBonus>>?` (personId → list of bonuses); nullable, default empty
+- [ ] `fromFirestore` / `toFirestore` handle `personBonuses` field correctly
+- [ ] `MeetingDetailScreen` participant list shows an "Add bonus" icon button per participant
+- [ ] Tapping "Add bonus" opens a dialog: point picker (1 / 2 / 3) + text field for comment (required)
+- [ ] Multiple bonuses can be added for the same participant in the same meeting — each is a separate entry
+- [ ] Existing bonuses for a participant are listed below their name in the meeting detail view (points + comment)
+- [ ] Each new bonus is auto-appended to meeting notes as: `"[FirstName] +[N]: [comment]"`
+- [ ] Bonus can be deleted — deletion also removes the corresponding auto-generated notes entry
+- [ ] `flutter analyze` clean, `flutter test` pass
+
+**Tasks:**
+- [ ] **TASK-130.1:** Create `PersonBonus` Freezed model in `lib/data/models/`; run build_runner — 1h
+- [ ] **TASK-130.2:** Add `personBonuses` field to `Meeting` model; update `fromFirestore`/`toFirestore`; run build_runner — 1.5h
+- [ ] **TASK-130.3:** Build `PersonBonusDialog` widget (point picker + comment field + save/cancel) — 1.5h
+- [ ] **TASK-130.4:** Extend `MeetingDetailScreen` participant section: "Add bonus" button per participant; display existing bonuses below name — 2h
+- [ ] **TASK-130.5:** Implement add/delete bonus in `MeetingRepository`: update `personBonuses` map + sync meeting notes — 1h
+
+**Dependencies:** US-022 (MeetingDetailScreen exists)
+**Blocks:** US-131
+
+---
+
+### US-131: Person Bonus — Statistics Integration
+
+**As a** user
+**I want to** bonus points awarded to a participant to affect relationship statistics
+**So that** people who go the extra mile at meetings are reflected as stronger relationships
+
+**Story Points:** 5
+**Priority:** P2
+**Labels:** `analytics`, `statistics`, `persons`
+**Status:** 📋 Planned
+**Feature:** FEATURE-033: Person Recognition — Bonus Points
+
+**Effective weight formula:**
+`effectiveWeight(person, meeting) = meeting.weight + sum(personBonuses[personId].points)`
+
+**Acceptance Criteria:**
+- [ ] `StatisticsRepository` exposes a helper `effectiveWeight(personId, meeting)` that computes meeting weight + all bonus points for that person
+- [ ] `getInteractionDistribution()` uses `effectiveWeight` per person instead of flat `meeting.weight`
+- [ ] `RelationshipScoreService.computeScore()` uses `effectiveWeight` when reading meeting data from `LocalCacheService`
+- [ ] `ActivityBreakdownWidget` is NOT affected — activity weight remains flat `meeting.weight`
+- [ ] Existing tests updated to cover `effectiveWeight` logic
+- [ ] `flutter analyze` clean, `flutter test` pass
+
+**Tasks:**
+- [ ] **TASK-131.1:** Add `effectiveWeight(personId, Meeting)` helper to `StatisticsRepository` — 1h
+- [ ] **TASK-131.2:** Refactor `getInteractionDistribution()` to use `effectiveWeight` per participant — 1h
+- [ ] **TASK-131.3:** Update `RelationshipScoreService.computeScore()` to apply `effectiveWeight` from `LocalCacheService` meeting data — 1.5h
+- [ ] **TASK-131.4:** Update `LocalCacheService` write-through so `personBonuses` is cached alongside meeting data — 0.5h
+
+**Dependencies:** US-130
 **Blocks:** None
 
 ---

--- a/docs/TEST_CASES.md
+++ b/docs/TEST_CASES.md
@@ -1922,3 +1922,70 @@ Run after every release or hotfix:
 | UT-122-015 | calls onLinkTap when tapped and unlinked | callback invoked |
 | UT-122-016 | does not call onLinkTap when tapped and already linked | callback not invoked |
 
+## US-123 — Couple Separation Flow
+
+### Automated tests — `test/data/repositories/person_repository_test.dart` (additions)
+
+| ID | Test name | Expected |
+|----|-----------|---------|
+| UT-123-001 | unlinkPartner clears partnerId and partnerLinkedAt on both persons | both Firestore docs have no partnerId/partnerLinkedAt |
+| UT-123-002 | unlinkPartner does not affect other persons | third person document unchanged |
+
+### Automated tests — `test/data/repositories/catch_up_topic_repository_test.dart` (additions)
+
+| ID | Test name | Expected |
+|----|-----------|---------|
+| UT-123-003 | applyRedistribution personA: keeps topic on A, deletes from B | A has topic, B does not |
+| UT-123-004 | applyRedistribution shared: keeps topic on both sides | both A and B have topic |
+| UT-123-005 | applyRedistribution personB: deletes from A, keeps on B | A missing topic, B has topic |
+| UT-123-006 | applyRedistribution delete: removes from both A and B | neither A nor B has topic |
+| UT-123-007 | applyRedistribution defaults to shared when topic id missing from decisions | both sides keep topic |
+| UT-123-008 | applyRedistribution personA no-op when partner has no matching topic | A topic unchanged, no exception |
+
+### Automated tests — `test/presentation/persons/person_detail_provider_test.dart` (additions)
+
+| ID | Test name | Expected |
+|----|-----------|---------|
+| UT-123-009 | clearPartner clears partnerId and partnerLinkedAt | both fields null after call |
+| UT-123-010 | clearPartner does nothing when person is null | no exception thrown |
+
+### Automated tests — `test/presentation/persons/couple_link_section_test.dart` (additions)
+
+| ID | Test name | Expected |
+|----|-----------|---------|
+| UT-123-011 | shows Unlink button when person is linked | 'Unlink' text visible |
+| UT-123-012 | does not show Unlink button when person is unlinked | 'Unlink' text absent |
+| UT-123-013 | calls onUnlinkTap when Unlink button pressed | callback invoked |
+
+### Automated tests — `test/presentation/persons/couple_separation_dialog_test.dart` (NEW)
+
+| ID | Test name | Expected |
+|----|-----------|---------|
+| UT-123-014 | shows Redistribute topics title | dialog title visible |
+| UT-123-015 | shows topic text for each post-link topic | topic text rendered |
+| UT-123-016 | shows ToggleButtons with 4 options per topic | Anna / Shared / Bob / Delete buttons present |
+| UT-123-017 | returns null when Cancel tapped | result is null |
+| UT-123-018 | returns decisions map with shared default when Confirm tapped | decisions[t1] == shared |
+| UT-123-019 | selecting a ToggleButtons option updates decision | decisions[t1] == delete after tapping Delete |
+| UT-123-020 | shows no ToggleButtons when postLinkTopics is empty | no ToggleButtons in tree |
+
+### Automated tests — `test/presentation/persons/catch_up_list_section_test.dart` (NEW)
+
+| ID | Test name | Expected |
+|----|-----------|---------|
+| UT-123-021 | shows Catch-up List title | text visible |
+| UT-123-022 | shows add icon button | Icons.add present |
+| UT-123-023 | calls onAddTap when add button pressed | callback invoked |
+| UT-123-024 | shows badge with topic count when topics present | '2' badge visible |
+| UT-123-025 | does not show badge when topics list is empty | '0' absent |
+| UT-123-026 | shows topic text when expanded | topic text visible |
+| UT-123-027 | shows "No topics yet" when expanded and empty | empty-state text visible |
+| UT-123-028 | shows CircularProgressIndicator when isLoading is true | spinner visible |
+
+### Automated tests — `test/presentation/persons/history_section_test.dart` (additions)
+
+| ID | Test name | Expected |
+|----|-----------|---------|
+| UT-123-029 | shows badge with count when archived topics present | '1' badge visible |
+| UT-123-030 | does not show badge when archived topics list is empty | '0' absent |
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -80,6 +80,7 @@ erDiagram
         array participantIds
         array categoryIds
         array notes "list of memory bullet points, each a short string (US-100)"
+        map personBonuses "nullable Map<personId, List<PersonBonus>>; each bonus: {points: 1-3, comment: String} (US-130)"
         datetime createdAt
         datetime updatedAt
     }
@@ -715,6 +716,31 @@ Score computed by `RelationshipScoreService.computeScore()` in `PersonDetailProv
 **Deduplication rule:** A topic that exists on both linked persons is considered shared — displayed once in Friends-Quest, with `sourceTopicId` pointing to the canonical version.
 
 **Separation rule:** Topics created BEFORE `partnerLinkedAt` → auto-return to original owner. Topics created AFTER `partnerLinkedAt` → redistribution dialog (Person A / Shared copy / Person B / Delete).
+
+---
+
+#### Person Recognition — Bonus Points (US-130, US-131)
+
+**Storage:** `personBonuses: Map<personId, List<{points, comment}>>` on the `Meeting` Firestore document.
+
+**PersonBonus model:**
+```dart
+PersonBonus {
+  points: int   // 1–3
+  comment: String
+}
+```
+
+**Effective weight formula (US-131):**
+`effectiveWeight(personId, meeting) = meeting.weight + sum(personBonuses[personId].points)`
+
+Applied in:
+- `StatisticsRepository.getInteractionDistribution()` — per-person weight uses effectiveWeight
+- `RelationshipScoreService.computeScore()` — frequency/recency scoring uses effectiveWeight
+- `ActivityBreakdownWidget` — NOT affected, uses flat `meeting.weight`
+
+**Auto-note on bonus add:** Each bonus appends `"[FirstName] +[N]: [comment]"` to `meeting.notes`.
+Deletion of a bonus removes the corresponding notes entry.
 
 ---
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -16,6 +16,7 @@
 - v2.6 — FR-033 added: Tool Calling (US-110) — Buddy queries only relevant data via OpenAI function calling, supports arbitrary date ranges; FR-034 added: Offline-First Mode (US-111) — full CRUD available offline via Firestore SDK write queue + Hive cache (US-109)
 - v2.7 — FR-035 added: Buddy Language Selection (US-113); FR-036 added: Buddy Onboarding (US-114); FR-037 added: Buddy Birthday Message Quality (US-115); FR-038 added: App UI Localization (US-116); FR-039 added: User-Defined Writing Style (US-117)
 - v2.8 — FR-040 added: Catch-up Topics per Person (US-120, US-121); FR-041 added: Couple/Family Link in Social Graph (US-122, US-123); FR-042 added: Friends-Quest pre-meeting tool (US-124, US-125, US-126, US-127)
+- v2.9 — FR-043 added: Person Recognition — Bonus Points (US-130, US-131)
 
 ---
 
@@ -629,6 +630,9 @@ User can link two Person records as a couple. Linked persons share all new catch
 
 ### FR-042: Friends-Quest — Pre-Meeting Preparation (M8)
 User can create named Friends-Quests (multiple active simultaneously), add participants, and auto-import their catch-up topics as tasks (deduplicated for couples). Tasks can be added, edited (edit propagates to source topic), and deleted (delete does NOT remove source topic). Quest can be linked to a meeting (1 quest : 1 meeting). Completing a quest pushes finished task notes to the linked meeting. Buddy can create and populate quests via "Others → Catch-up topics" flow. Stored locally in Hive only (not synced to Firestore). Accessible from sidebar + optional home widget. Implemented in US-124–US-127.
+
+### FR-043: Person Recognition — Bonus Points (M8)
+User can award bonus points (1–3) with a mandatory comment to individual meeting participants from the Meeting Detail screen. Multiple bonuses can be added per person per meeting; they all stack. Effective weight for a person in a meeting = `meeting.weight + sum of their bonuses`. Each bonus auto-appends to meeting notes as `"[FirstName] +[N]: [comment]"`. Deletion of a bonus removes its notes entry. Bonus points affect Interaction Distribution and Relationship Score statistics; Activity Breakdown is unaffected (uses flat meeting weight). Implemented in US-130–US-131.
 
 ---
 

--- a/docs/wireframes.md
+++ b/docs/wireframes.md
@@ -263,11 +263,30 @@ Each card:
 │  ⚖  Weight: 3                       │
 │                                     │
 │  Participants                        │
-│  Anna Smith · John Doe              │
+│  Anna Smith                    [+]  │
+│    ⭐ +2: Zorganizowała całe wyjście │
+│  John Doe                      [+]  │
 │                                     │
 │  Activities                          │
 │  ☕ Coffee · 🏃 Running              │
 │                                     │
+└─────────────────────────────────────┘
+```
+
+**Person Bonus Dialog (US-130):**
+```
+┌─────────────────────────────────────┐
+│  Bonus dla Anna Smith               │
+├─────────────────────────────────────┤
+│  Punkty                             │
+│  ○ 1   ● 2   ○ 3                   │
+│                                     │
+│  Za co?                             │
+│  ┌─────────────────────────────┐   │
+│  │ Zorganizowała całe wyjście  │   │
+│  └─────────────────────────────┘   │
+│                                     │
+│         [Anuluj]  [Dodaj bonus]     │
 └─────────────────────────────────────┘
 ```
 
@@ -276,6 +295,9 @@ Each card:
 - `🗑` → confirmation dialog → delete → back to `MeetingsListScreen`
 - Participants shown as resolved full names (not IDs)
 - Activities shown with category icons
+- `[+]` per participant → opens PersonBonusDialog (point picker 1–3 + required comment)
+- Existing bonuses shown below participant name (star icon + points + comment)
+- Long press on bonus → delete confirmation → removes bonus and its notes entry
 
 ---
 

--- a/lib/data/repositories/catch_up_topic_repository.dart
+++ b/lib/data/repositories/catch_up_topic_repository.dart
@@ -3,6 +3,9 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import '../models/catch_up_topic.dart';
 import '../services/local_cache_service.dart';
 
+// Redistribution decision for a shared topic during couple separation.
+enum TopicRedistributionDecision { personA, shared, personB, delete }
+
 class CatchUpTopicRepository {
   final FirebaseFirestore _firestore;
 
@@ -167,5 +170,47 @@ class CatchUpTopicRepository {
   ) async {
     await _topicsRef(userId, personId).doc(topicId).delete();
     await LocalCacheService().removeTopic(userId, personId, topicId);
+  }
+
+  /// Applies redistribution decisions after couple separation.
+  /// personId = primary person, partnerId = partner.
+  /// postLinkTopics: active topics for personId created on/after partnerLinkedAt.
+  /// Partner-side matching: case-insensitive text trim.
+  Future<void> applyRedistribution(
+    String userId,
+    String personId,
+    String partnerId,
+    List<CatchUpTopic> postLinkTopics,
+    Map<String, TopicRedistributionDecision> decisions,
+  ) async {
+    final partnerTopics = await getActive(userId, partnerId);
+    for (final topic in postLinkTopics) {
+      final decision =
+          decisions[topic.id] ?? TopicRedistributionDecision.shared;
+      final normalizedText = topic.text.trim().toLowerCase();
+      final partnerMatch = partnerTopics.cast<CatchUpTopic?>().firstWhere(
+        (t) => t!.text.trim().toLowerCase() == normalizedText,
+        orElse: () => null,
+      );
+      switch (decision) {
+        case TopicRedistributionDecision.personA:
+          // Keep on A, delete from B.
+          if (partnerMatch != null) {
+            await delete(userId, partnerId, partnerMatch.id);
+          }
+        case TopicRedistributionDecision.shared:
+          // Keep both — no action.
+          break;
+        case TopicRedistributionDecision.personB:
+          // Keep on B, delete from A.
+          await delete(userId, personId, topic.id);
+        case TopicRedistributionDecision.delete:
+          // Delete from both.
+          await delete(userId, personId, topic.id);
+          if (partnerMatch != null) {
+            await delete(userId, partnerId, partnerMatch.id);
+          }
+      }
+    }
   }
 }

--- a/lib/data/repositories/catch_up_topic_repository.dart
+++ b/lib/data/repositories/catch_up_topic_repository.dart
@@ -189,9 +189,9 @@ class CatchUpTopicRepository {
           decisions[topic.id] ?? TopicRedistributionDecision.shared;
       final normalizedText = topic.text.trim().toLowerCase();
       final partnerMatch = partnerTopics.cast<CatchUpTopic?>().firstWhere(
-        (t) => t!.text.trim().toLowerCase() == normalizedText,
-        orElse: () => null,
-      );
+            (t) => t!.text.trim().toLowerCase() == normalizedText,
+            orElse: () => null,
+          );
       switch (decision) {
         case TopicRedistributionDecision.personA:
           // Keep on A, delete from B.

--- a/lib/data/repositories/person_repository.dart
+++ b/lib/data/repositories/person_repository.dart
@@ -128,6 +128,41 @@ class PersonRepository {
     }
   }
 
+  /// Clears partnerId + partnerLinkedAt on both persons using a batch write.
+  /// Write-through: re-fetches both persons from Firestore and upserts to Hive.
+  Future<void> unlinkPartner(
+    String userId,
+    String personId,
+    String partnerId,
+  ) async {
+    final batch = _firestore.batch();
+
+    final personRef = _personsRef(userId).doc(personId);
+    final partnerRef = _personsRef(userId).doc(partnerId);
+
+    batch.update(personRef, {
+      'partnerId': FieldValue.delete(),
+      'partnerLinkedAt': FieldValue.delete(),
+    });
+    batch.update(partnerRef, {
+      'partnerId': FieldValue.delete(),
+      'partnerLinkedAt': FieldValue.delete(),
+    });
+
+    await batch.commit();
+
+    final personSnap = await personRef.get();
+    final partnerSnap = await partnerRef.get();
+    if (personSnap.exists) {
+      await LocalCacheService()
+          .upsertPerson(userId, Person.fromFirestore(personSnap));
+    }
+    if (partnerSnap.exists) {
+      await LocalCacheService()
+          .upsertPerson(userId, Person.fromFirestore(partnerSnap));
+    }
+  }
+
   /// Deletes a person and removes them from all associated meetings atomically.
   Future<void> deletePerson(String userId, String personId) async {
     // Remove personId from meetings and groups before deleting the person

--- a/lib/presentation/persons/catch_up_list_section.dart
+++ b/lib/presentation/persons/catch_up_list_section.dart
@@ -57,6 +57,22 @@ class CatchUpListSection extends StatelessWidget {
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
+          // Badge showing active topic count — matches child activities style.
+          if (topics.isNotEmpty)
+            Container(
+              margin: const EdgeInsets.only(right: 4),
+              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.primary.withValues(alpha: 0.15),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Text(
+                '${topics.length}',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.primary,
+                ),
+              ),
+            ),
           IconButton(
             icon: const Icon(Icons.add),
             tooltip: 'Add topic',

--- a/lib/presentation/persons/couple_link_section.dart
+++ b/lib/presentation/persons/couple_link_section.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import '../../data/models/person.dart';
 
 /// Displays couple link status on PersonDetailScreen.
-/// Shows "Link as couple" tile when unlinked, partner's name when linked.
+/// Shows "Link as couple" tile when unlinked, partner name + Unlink button when linked.
 class CoupleLinkSection extends StatelessWidget {
   final Person person;
 
@@ -13,11 +13,15 @@ class CoupleLinkSection extends StatelessWidget {
   /// Called when the user taps "Link as couple". Opens the link flow.
   final VoidCallback onLinkTap;
 
+  /// Called when the user taps "Unlink". Opens the separation flow.
+  final VoidCallback? onUnlinkTap;
+
   const CoupleLinkSection({
     super.key,
     required this.person,
     required this.partnerPerson,
     required this.onLinkTap,
+    this.onUnlinkTap,
   });
 
   @override
@@ -30,7 +34,14 @@ class CoupleLinkSection extends StatelessWidget {
       subtitle: isLinked && partnerPerson != null
           ? Text('Linked with ${partnerPerson!.fullName}')
           : null,
+      // Tile tap is only active when unlinked; unlink is triggered via trailing button.
       onTap: isLinked ? null : onLinkTap,
+      trailing: isLinked
+          ? TextButton(
+              onPressed: onUnlinkTap,
+              child: const Text('Unlink'),
+            )
+          : null,
     );
   }
 }

--- a/lib/presentation/persons/couple_separation_dialog.dart
+++ b/lib/presentation/persons/couple_separation_dialog.dart
@@ -105,15 +105,13 @@ class _CoupleSeparationDialogState extends State<CoupleSeparationDialog> {
               d == TopicRedistributionDecision.delete,
             ],
             onPressed: (i) => setState(
-              () => _decisions[topic.id] =
-                  TopicRedistributionDecision.values[i],
+              () =>
+                  _decisions[topic.id] = TopicRedistributionDecision.values[i],
             ),
             children: [
-              Text(widget.personAName,
-                  style: const TextStyle(fontSize: 12)),
+              Text(widget.personAName, style: const TextStyle(fontSize: 12)),
               const Text('Shared', style: TextStyle(fontSize: 12)),
-              Text(widget.personBName,
-                  style: const TextStyle(fontSize: 12)),
+              Text(widget.personBName, style: const TextStyle(fontSize: 12)),
               const Text('Delete', style: TextStyle(fontSize: 12)),
             ],
           ),

--- a/lib/presentation/persons/couple_separation_dialog.dart
+++ b/lib/presentation/persons/couple_separation_dialog.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+
+import '../../data/models/catch_up_topic.dart';
+import '../../data/repositories/catch_up_topic_repository.dart';
+
+/// Dialog shown during couple separation to let the user decide what happens
+/// to topics that were created after the couple linked (post-link topics).
+///
+/// Each topic is shown with a 4-state ToggleButtons selector:
+/// [personA] | [Shared] | [personB] | [Delete]
+///
+/// Returns Map<topicId, TopicRedistributionDecision> on confirm, null on cancel.
+class CoupleSeparationDialog extends StatefulWidget {
+  /// First name of the primary person (Person A).
+  final String personAName;
+
+  /// First name of the partner (Person B).
+  final String personBName;
+
+  /// Topics created on or after partnerLinkedAt that require user redistribution.
+  final List<CatchUpTopic> postLinkTopics;
+
+  const CoupleSeparationDialog({
+    super.key,
+    required this.personAName,
+    required this.personBName,
+    required this.postLinkTopics,
+  });
+
+  @override
+  State<CoupleSeparationDialog> createState() => _CoupleSeparationDialogState();
+}
+
+class _CoupleSeparationDialogState extends State<CoupleSeparationDialog> {
+  // Keyed by topic.id; all initialized to shared (safe default).
+  late final Map<String, TopicRedistributionDecision> _decisions;
+
+  @override
+  void initState() {
+    super.initState();
+    _decisions = {
+      for (final t in widget.postLinkTopics)
+        t.id: TopicRedistributionDecision.shared,
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('Redistribute topics'),
+      // SizedBox(width: maxFinite) prevents IntrinsicWidth from collapsing the
+      // dialog too narrow for the ToggleButtons row.
+      content: SizedBox(
+        width: double.maxFinite,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxHeight: 400),
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text(
+                  'Choose what happens to each shared topic after unlinking.',
+                ),
+                const SizedBox(height: 12),
+                ...widget.postLinkTopics.map(_buildTopicRow),
+              ],
+            ),
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(null),
+          child: const Text('Cancel'),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(Map.of(_decisions)),
+          child: const Text('Confirm'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTopicRow(CatchUpTopic topic) {
+    final d = _decisions[topic.id]!;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            topic.text,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(fontWeight: FontWeight.w500),
+          ),
+          const SizedBox(height: 4),
+          ToggleButtons(
+            constraints: const BoxConstraints(minWidth: 60, minHeight: 36),
+            isSelected: [
+              d == TopicRedistributionDecision.personA,
+              d == TopicRedistributionDecision.shared,
+              d == TopicRedistributionDecision.personB,
+              d == TopicRedistributionDecision.delete,
+            ],
+            onPressed: (i) => setState(
+              () => _decisions[topic.id] =
+                  TopicRedistributionDecision.values[i],
+            ),
+            children: [
+              Text(widget.personAName,
+                  style: const TextStyle(fontSize: 12)),
+              const Text('Shared', style: TextStyle(fontSize: 12)),
+              Text(widget.personBName,
+                  style: const TextStyle(fontSize: 12)),
+              const Text('Delete', style: TextStyle(fontSize: 12)),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/persons/history_section.dart
+++ b/lib/presentation/persons/history_section.dart
@@ -104,8 +104,7 @@ class _HistorySectionState extends State<HistorySection> {
               const SizedBox(width: 6),
               // Badge matching child activities style (green pill).
               Container(
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
                 decoration: BoxDecoration(
                   color: theme.colorScheme.primary.withValues(alpha: 0.15),
                   borderRadius: BorderRadius.circular(10),

--- a/lib/presentation/persons/history_section.dart
+++ b/lib/presentation/persons/history_section.dart
@@ -94,7 +94,32 @@ class _HistorySectionState extends State<HistorySection> {
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: ExpansionTile(
         leading: const Icon(Icons.history),
-        title: const Text('Historia'),
+        // Title uses a Row so 'Historia' remains as a standalone Text widget —
+        // required for find.text('Historia') in widget tests to keep working.
+        title: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text('Historia'),
+            if (widget.archivedTopics.isNotEmpty) ...[
+              const SizedBox(width: 6),
+              // Badge matching child activities style (green pill).
+              Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.primary.withValues(alpha: 0.15),
+                  borderRadius: BorderRadius.circular(10),
+                ),
+                child: Text(
+                  '${widget.archivedTopics.length}',
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    color: theme.colorScheme.primary,
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
         tilePadding: EdgeInsets.zero,
         childrenPadding: EdgeInsets.zero,
         onExpansionChanged: (expanded) {

--- a/lib/presentation/persons/person_detail_provider.dart
+++ b/lib/presentation/persons/person_detail_provider.dart
@@ -77,6 +77,14 @@ class PersonDetailProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  // Clears partnerId and partnerLinkedAt locally after couple separation.
+  // Lightweight — does not re-fetch meeting count or score.
+  void clearPartner() {
+    if (_person == null) return;
+    _person = _person!.copyWith(partnerId: null, partnerLinkedAt: null);
+    notifyListeners();
+  }
+
   // Silently re-fetches meeting count without setting isLoading.
   // Used to sync the count after returning from PersonMeetingsScreen.
   Future<void> refreshMeetingCount() async {

--- a/lib/presentation/persons/person_detail_screen.dart
+++ b/lib/presentation/persons/person_detail_screen.dart
@@ -16,6 +16,7 @@ import '../sharing/share_meetings_provider.dart';
 import '../sharing/share_meetings_screen.dart';
 import 'catch_up_list_section.dart';
 import 'couple_link_section.dart';
+import 'couple_separation_dialog.dart';
 import 'friend_groups_provider.dart';
 import 'history_section.dart';
 import 'nicknames_section.dart';
@@ -230,6 +231,121 @@ class _PersonDetailScreenState extends State<PersonDetailScreen> {
     }
   }
 
+  // Orchestrates couple separation: confirmation -> post-link topic split ->
+  // redistribution dialog (if needed) -> applyRedistribution -> unlinkPartner -> UI refresh.
+  Future<void> _showSeparationFlow() async {
+    final person =
+        context.read<PersonDetailProvider>().person ?? widget.person;
+    final partnerId = person.partnerId;
+    final partnerLinkedAt = person.partnerLinkedAt;
+    if (partnerId == null || partnerLinkedAt == null || !mounted) return;
+
+    // Step 1: Confirmation dialog.
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Unlink partner?'),
+        content: Text(
+          'Unlink ${_partnerPerson?.firstName ?? 'partner'} as your partner? '
+          'You can re-link them at any time.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
+            child: const Text('Unlink'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+
+    final userId = AuthService().currentUserId!;
+
+    // Step 2: Load both persons' active topics to classify pre/post-link correctly.
+    final personTopics =
+        await _catchUpRepo.getActive(userId, widget.person.id);
+    final partnerTopics =
+        await _catchUpRepo.getActive(userId, partnerId);
+    if (!mounted) return;
+
+    // Pre-link text sets (lowercase trimmed) — topics that existed before linking.
+    final personPreLinkTexts = personTopics
+        .where((t) => t.createdAt.isBefore(partnerLinkedAt))
+        .map((t) => t.text.trim().toLowerCase())
+        .toSet();
+    final partnerPreLinkTexts = partnerTopics
+        .where((t) => t.createdAt.isBefore(partnerLinkedAt))
+        .map((t) => t.text.trim().toLowerCase())
+        .toSet();
+
+    // Genuine couple-era topics: created on/after linking AND not a merged copy of
+    // a partner's pre-link topic. mergeTopics() creates copies at link time with
+    // createdAt >= partnerLinkedAt, so filtering by text excludes them correctly.
+    final postLinkTopics = personTopics
+        .where((t) =>
+            !t.createdAt.isBefore(partnerLinkedAt) &&
+            !partnerPreLinkTexts.contains(t.text.trim().toLowerCase()))
+        .toList();
+
+    // Step 3: Show redistribution dialog only for genuine couple-era topics.
+    if (postLinkTopics.isNotEmpty) {
+      final decisions =
+          await showDialog<Map<String, TopicRedistributionDecision>>(
+        context: context,
+        builder: (ctx) => CoupleSeparationDialog(
+          personAName: widget.person.firstName,
+          personBName: _partnerPerson?.firstName ?? 'Partner',
+          postLinkTopics: postLinkTopics,
+        ),
+      );
+      if (decisions == null || !mounted) return;
+
+      await _catchUpRepo.applyRedistribution(
+        userId,
+        widget.person.id,
+        partnerId,
+        postLinkTopics,
+        decisions,
+      );
+      if (!mounted) return;
+    }
+
+    // Step 4: Auto-remove partner's pre-link topics that were merged to this person.
+    // Text in partnerPreLinkTexts but NOT in personPreLinkTexts = merged copies.
+    for (final topic in personTopics) {
+      final normalized = topic.text.trim().toLowerCase();
+      if (partnerPreLinkTexts.contains(normalized) &&
+          !personPreLinkTexts.contains(normalized)) {
+        await _catchUpRepo.delete(userId, widget.person.id, topic.id);
+      }
+    }
+    if (!mounted) return;
+
+    // Step 5: Auto-remove this person's pre-link topics that were merged to partner.
+    for (final topic in partnerTopics) {
+      final normalized = topic.text.trim().toLowerCase();
+      if (personPreLinkTexts.contains(normalized) &&
+          !partnerPreLinkTexts.contains(normalized)) {
+        await _catchUpRepo.delete(userId, partnerId, topic.id);
+      }
+    }
+    if (!mounted) return;
+
+    // Step 6: Unlink on both persons.
+    await _personRepo.unlinkPartner(userId, widget.person.id, partnerId);
+    if (!mounted) return;
+
+    // Step 7: Refresh UI state.
+    context.read<PersonDetailProvider>().clearPartner();
+    setState(() => _partnerPerson = null);
+    await _loadTopics();
+  }
+
   Future<void> _addTopic(String text, String? label) async {
     // Read partnerId before any await to avoid using BuildContext across async gaps.
     final partnerId = context.read<PersonDetailProvider>().person?.partnerId ??
@@ -270,11 +386,43 @@ class _PersonDetailScreenState extends State<PersonDetailScreen> {
   }
 
   Future<void> _deleteTopic(String topicId) async {
+    // Capture topic text before removal for partner propagation.
+    final topic = _topics.firstWhere(
+      (t) => t.id == topicId,
+      orElse: () => CatchUpTopic(id: topicId, text: '', createdAt: DateTime.now()),
+    );
+    // Read partnerId before any await to avoid using BuildContext across async gaps.
+    final partnerId = context.read<PersonDetailProvider>().person?.partnerId ??
+        widget.person.partnerId;
     // Optimistic removal so the UI feels instant.
     setState(() => _topics = _topics.where((t) => t.id != topicId).toList());
     try {
       final userId = AuthService().currentUserId!;
       await _catchUpRepo.delete(userId, widget.person.id, topicId);
+      // Mirror delete to partner if linked (fire-and-forget).
+      if (partnerId != null && topic.text.isNotEmpty) {
+        _deletePartnerTopicByText(userId, partnerId, topic.text);
+      }
+    } catch (_) {}
+  }
+
+  // Finds the matching active topic on the partner by case-insensitive text
+  // and deletes it. Fire-and-forget — failure must not affect the UI.
+  Future<void> _deletePartnerTopicByText(
+    String userId,
+    String partnerId,
+    String text,
+  ) async {
+    try {
+      final partnerTopics = await _catchUpRepo.getActive(userId, partnerId);
+      final normalizedText = text.trim().toLowerCase();
+      final match = partnerTopics.cast<CatchUpTopic?>().firstWhere(
+        (t) => t!.text.trim().toLowerCase() == normalizedText,
+        orElse: () => null,
+      );
+      if (match != null) {
+        await _catchUpRepo.delete(userId, partnerId, match.id);
+      }
     } catch (_) {}
   }
 
@@ -399,6 +547,7 @@ class _PersonDetailScreenState extends State<PersonDetailScreen> {
         onDeleteArchivedTopic: _deleteArchivedTopic,
         partnerPerson: _partnerPerson,
         onCoupleLinkTap: _showCoupleLinkFlow,
+        onUnlinkTap: _showSeparationFlow,
       ),
     );
   }
@@ -1121,6 +1270,7 @@ class _PersonDetailBody extends StatelessWidget {
   final Future<void> Function(String topicId) onDeleteArchivedTopic;
   final Person? partnerPerson;
   final VoidCallback onCoupleLinkTap;
+  final VoidCallback? onUnlinkTap;
 
   const _PersonDetailBody({
     required this.provider,
@@ -1141,6 +1291,7 @@ class _PersonDetailBody extends StatelessWidget {
     required this.onDeleteArchivedTopic,
     required this.partnerPerson,
     required this.onCoupleLinkTap,
+    this.onUnlinkTap,
   });
 
   @override
@@ -1210,6 +1361,7 @@ class _PersonDetailBody extends StatelessWidget {
           person: person,
           partnerPerson: partnerPerson,
           onLinkTap: onCoupleLinkTap,
+          onUnlinkTap: onUnlinkTap,
         ),
         NicknamesSection(provider: provider, person: person),
         _GroupsSection(person: person),

--- a/lib/presentation/persons/person_detail_screen.dart
+++ b/lib/presentation/persons/person_detail_screen.dart
@@ -234,8 +234,7 @@ class _PersonDetailScreenState extends State<PersonDetailScreen> {
   // Orchestrates couple separation: confirmation -> post-link topic split ->
   // redistribution dialog (if needed) -> applyRedistribution -> unlinkPartner -> UI refresh.
   Future<void> _showSeparationFlow() async {
-    final person =
-        context.read<PersonDetailProvider>().person ?? widget.person;
+    final person = context.read<PersonDetailProvider>().person ?? widget.person;
     final partnerId = person.partnerId;
     final partnerLinkedAt = person.partnerLinkedAt;
     if (partnerId == null || partnerLinkedAt == null || !mounted) return;
@@ -267,10 +266,8 @@ class _PersonDetailScreenState extends State<PersonDetailScreen> {
     final userId = AuthService().currentUserId!;
 
     // Step 2: Load both persons' active topics to classify pre/post-link correctly.
-    final personTopics =
-        await _catchUpRepo.getActive(userId, widget.person.id);
-    final partnerTopics =
-        await _catchUpRepo.getActive(userId, partnerId);
+    final personTopics = await _catchUpRepo.getActive(userId, widget.person.id);
+    final partnerTopics = await _catchUpRepo.getActive(userId, partnerId);
     if (!mounted) return;
 
     // Pre-link text sets (lowercase trimmed) — topics that existed before linking.
@@ -389,7 +386,8 @@ class _PersonDetailScreenState extends State<PersonDetailScreen> {
     // Capture topic text before removal for partner propagation.
     final topic = _topics.firstWhere(
       (t) => t.id == topicId,
-      orElse: () => CatchUpTopic(id: topicId, text: '', createdAt: DateTime.now()),
+      orElse: () =>
+          CatchUpTopic(id: topicId, text: '', createdAt: DateTime.now()),
     );
     // Read partnerId before any await to avoid using BuildContext across async gaps.
     final partnerId = context.read<PersonDetailProvider>().person?.partnerId ??
@@ -417,9 +415,9 @@ class _PersonDetailScreenState extends State<PersonDetailScreen> {
       final partnerTopics = await _catchUpRepo.getActive(userId, partnerId);
       final normalizedText = text.trim().toLowerCase();
       final match = partnerTopics.cast<CatchUpTopic?>().firstWhere(
-        (t) => t!.text.trim().toLowerCase() == normalizedText,
-        orElse: () => null,
-      );
+            (t) => t!.text.trim().toLowerCase() == normalizedText,
+            orElse: () => null,
+          );
       if (match != null) {
         await _catchUpRepo.delete(userId, partnerId, match.id);
       }

--- a/test/data/repositories/catch_up_topic_repository_test.dart
+++ b/test/data/repositories/catch_up_topic_repository_test.dart
@@ -215,6 +215,147 @@ void main() {
       });
     });
 
+    group('applyRedistribution', () {
+      const partnerId = 'p2';
+
+      CollectionReference partnerTopicsRef() => fakeFirestore
+          .collection('users')
+          .doc(userId)
+          .collection('persons')
+          .doc(partnerId)
+          .collection('catch_up_topics');
+
+      Future<String> seedPartnerTopic({String text = 'Partner topic'}) async {
+        final ref = await partnerTopicsRef().add({
+          'text': text,
+          'createdAt': Timestamp.fromDate(DateTime(2026, 4, 10)),
+          'isArchived': false,
+        });
+        return ref.id;
+      }
+
+      test('personA: keeps topic on A, deletes matching topic from B',
+          () async {
+        final topicId = await seedTopic(text: 'Shared');
+        await seedPartnerTopic(text: 'Shared');
+
+        final topic = (await repository.getActive(userId, personId)).first;
+
+        await repository.applyRedistribution(
+          userId,
+          personId,
+          partnerId,
+          [topic],
+          {topicId: TopicRedistributionDecision.personA},
+        );
+
+        final personTopics = await repository.getActive(userId, personId);
+        final partnerTopics = await repository.getActive(userId, partnerId);
+        expect(personTopics.any((t) => t.text == 'Shared'), isTrue);
+        expect(partnerTopics.any((t) => t.text == 'Shared'), isFalse);
+      });
+
+      test('shared: keeps topic on both sides', () async {
+        final topicId = await seedTopic(text: 'Keep both');
+        await seedPartnerTopic(text: 'Keep both');
+
+        final topic = (await repository.getActive(userId, personId)).first;
+
+        await repository.applyRedistribution(
+          userId,
+          personId,
+          partnerId,
+          [topic],
+          {topicId: TopicRedistributionDecision.shared},
+        );
+
+        final personTopics = await repository.getActive(userId, personId);
+        final partnerTopics = await repository.getActive(userId, partnerId);
+        expect(personTopics.any((t) => t.text == 'Keep both'), isTrue);
+        expect(partnerTopics.any((t) => t.text == 'Keep both'), isTrue);
+      });
+
+      test('personB: deletes topic from A, keeps it on B', () async {
+        final topicId = await seedTopic(text: 'For B only');
+        await seedPartnerTopic(text: 'For B only');
+
+        final topic = (await repository.getActive(userId, personId)).first;
+
+        await repository.applyRedistribution(
+          userId,
+          personId,
+          partnerId,
+          [topic],
+          {topicId: TopicRedistributionDecision.personB},
+        );
+
+        final personTopics = await repository.getActive(userId, personId);
+        final partnerTopics = await repository.getActive(userId, partnerId);
+        expect(personTopics.any((t) => t.text == 'For B only'), isFalse);
+        expect(partnerTopics.any((t) => t.text == 'For B only'), isTrue);
+      });
+
+      test('delete: removes topic from both A and B', () async {
+        final topicId = await seedTopic(text: 'Remove all');
+        await seedPartnerTopic(text: 'Remove all');
+
+        final topic = (await repository.getActive(userId, personId)).first;
+
+        await repository.applyRedistribution(
+          userId,
+          personId,
+          partnerId,
+          [topic],
+          {topicId: TopicRedistributionDecision.delete},
+        );
+
+        final personTopics = await repository.getActive(userId, personId);
+        final partnerTopics = await repository.getActive(userId, partnerId);
+        expect(personTopics.any((t) => t.text == 'Remove all'), isFalse);
+        expect(partnerTopics.any((t) => t.text == 'Remove all'), isFalse);
+      });
+
+      test('defaults to shared when topic id missing from decisions map',
+          () async {
+        final topicId = await seedTopic(text: 'Default shared');
+        await seedPartnerTopic(text: 'Default shared');
+
+        final topic = (await repository.getActive(userId, personId)).first;
+
+        // Pass empty decisions — should default to shared.
+        await repository.applyRedistribution(
+          userId,
+          personId,
+          partnerId,
+          [topic],
+          {},
+        );
+
+        final personTopics = await repository.getActive(userId, personId);
+        final partnerTopics = await repository.getActive(userId, partnerId);
+        expect(personTopics.any((t) => t.id == topicId), isTrue);
+        expect(partnerTopics.any((t) => t.text == 'Default shared'), isTrue);
+      });
+
+      test('personA: no-op when partner has no matching topic', () async {
+        final topicId = await seedTopic(text: 'Only on A');
+
+        final topic = (await repository.getActive(userId, personId)).first;
+
+        await repository.applyRedistribution(
+          userId,
+          personId,
+          partnerId,
+          [topic],
+          {topicId: TopicRedistributionDecision.personA},
+        );
+
+        // Topic should still exist on A; nothing thrown.
+        final personTopics = await repository.getActive(userId, personId);
+        expect(personTopics.any((t) => t.text == 'Only on A'), isTrue);
+      });
+    });
+
     group('mergeTopics', () {
       const partnerId = 'p2';
 

--- a/test/data/repositories/person_repository_test.dart
+++ b/test/data/repositories/person_repository_test.dart
@@ -244,5 +244,52 @@ void main() {
         expect(docB.data()?['partnerLinkedAt'], isNotNull);
       });
     });
+
+    group('unlinkPartner', () {
+      late Directory hiveDir;
+
+      setUp(() async {
+        hiveDir = await Directory.systemTemp.createTemp('hive_person_unlink_');
+        await HiveService.initialize(testPath: hiveDir.path);
+      });
+
+      tearDown(() async {
+        await Hive.close();
+        await hiveDir.delete(recursive: true);
+      });
+
+      test('clears partnerId and partnerLinkedAt on both persons in Firestore',
+          () async {
+        final a =
+            await repository.addPerson(makePerson(id: 'a', firstName: 'Anna'));
+        final b =
+            await repository.addPerson(makePerson(id: 'b', firstName: 'Bob'));
+
+        await repository.linkPartner('user-1', a.id, b.id);
+        await repository.unlinkPartner('user-1', a.id, b.id);
+
+        final docA = await personsRef('user-1').doc(a.id).get();
+        final docB = await personsRef('user-1').doc(b.id).get();
+        expect(docA.data()?['partnerId'], isNull);
+        expect(docA.data()?['partnerLinkedAt'], isNull);
+        expect(docB.data()?['partnerId'], isNull);
+        expect(docB.data()?['partnerLinkedAt'], isNull);
+      });
+
+      test('does not affect other persons in Firestore', () async {
+        final a =
+            await repository.addPerson(makePerson(id: 'a', firstName: 'Anna'));
+        final b =
+            await repository.addPerson(makePerson(id: 'b', firstName: 'Bob'));
+        final c =
+            await repository.addPerson(makePerson(id: 'c', firstName: 'Carl'));
+
+        await repository.linkPartner('user-1', a.id, b.id);
+        await repository.unlinkPartner('user-1', a.id, b.id);
+
+        final docC = await personsRef('user-1').doc(c.id).get();
+        expect(docC.exists, isTrue);
+      });
+    });
   });
 }

--- a/test/presentation/persons/catch_up_list_section_test.dart
+++ b/test/presentation/persons/catch_up_list_section_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:friendsheet/data/models/catch_up_topic.dart';
+import 'package:friendsheet/presentation/persons/catch_up_list_section.dart';
+
+void main() {
+  CatchUpTopic makeTopic({String id = 't1', String text = 'Topic'}) {
+    return CatchUpTopic(
+      id: id,
+      text: text,
+      createdAt: DateTime(2026, 4, 1),
+    );
+  }
+
+  Widget buildSection({
+    List<CatchUpTopic> topics = const [],
+    bool isLoading = false,
+    VoidCallback? onAddTap,
+    Future<void> Function(String)? onDelete,
+    void Function(CatchUpTopic)? onEdit,
+    Future<void> Function(String)? onArchive,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: CatchUpListSection(
+          topics: topics,
+          isLoading: isLoading,
+          personId: 'p1',
+          onAddTap: onAddTap ?? () {},
+          onDelete: onDelete ?? (_) async {},
+          onEdit: onEdit ?? (_) {},
+          onArchive: onArchive ?? (_) async {},
+        ),
+      ),
+    );
+  }
+
+  group('CatchUpListSection', () {
+    testWidgets('shows Catch-up List title', (tester) async {
+      await tester.pumpWidget(buildSection());
+
+      expect(find.text('Catch-up List'), findsOneWidget);
+    });
+
+    testWidgets('shows add icon button', (tester) async {
+      await tester.pumpWidget(buildSection());
+
+      expect(find.byIcon(Icons.add), findsOneWidget);
+    });
+
+    testWidgets('calls onAddTap when add button pressed', (tester) async {
+      var called = false;
+      await tester.pumpWidget(buildSection(onAddTap: () => called = true));
+
+      await tester.tap(find.byIcon(Icons.add));
+      expect(called, isTrue);
+    });
+
+    testWidgets('shows badge with topic count when topics present',
+        (tester) async {
+      final topics = [
+        makeTopic(id: 't1'),
+        makeTopic(id: 't2', text: 'Second'),
+      ];
+      await tester.pumpWidget(buildSection(topics: topics));
+
+      expect(find.text('2'), findsOneWidget);
+    });
+
+    testWidgets('does not show badge when topics list is empty', (tester) async {
+      await tester.pumpWidget(buildSection(topics: []));
+
+      // No numeric badge — '0' must not appear.
+      expect(find.text('0'), findsNothing);
+    });
+
+    testWidgets('shows topic text when expanded', (tester) async {
+      final topics = [makeTopic(text: 'Buy milk')];
+      await tester.pumpWidget(buildSection(topics: topics));
+
+      await tester.tap(find.text('Catch-up List'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Buy milk'), findsOneWidget);
+    });
+
+    testWidgets('shows "No topics yet" when expanded and empty', (tester) async {
+      await tester.pumpWidget(buildSection(topics: []));
+
+      await tester.tap(find.text('Catch-up List'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('No topics yet'), findsOneWidget);
+    });
+
+    testWidgets('shows CircularProgressIndicator when isLoading is true',
+        (tester) async {
+      await tester.pumpWidget(buildSection(isLoading: true));
+
+      await tester.tap(find.text('Catch-up List'));
+      await tester.pump();
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+  });
+}

--- a/test/presentation/persons/catch_up_list_section_test.dart
+++ b/test/presentation/persons/catch_up_list_section_test.dart
@@ -67,7 +67,8 @@ void main() {
       expect(find.text('2'), findsOneWidget);
     });
 
-    testWidgets('does not show badge when topics list is empty', (tester) async {
+    testWidgets('does not show badge when topics list is empty',
+        (tester) async {
       await tester.pumpWidget(buildSection(topics: []));
 
       // No numeric badge — '0' must not appear.
@@ -84,7 +85,8 @@ void main() {
       expect(find.text('Buy milk'), findsOneWidget);
     });
 
-    testWidgets('shows "No topics yet" when expanded and empty', (tester) async {
+    testWidgets('shows "No topics yet" when expanded and empty',
+        (tester) async {
       await tester.pumpWidget(buildSection(topics: []));
 
       await tester.tap(find.text('Catch-up List'));

--- a/test/presentation/persons/couple_link_section_test.dart
+++ b/test/presentation/persons/couple_link_section_test.dart
@@ -26,6 +26,7 @@ void main() {
     required Person person,
     Person? partnerPerson,
     VoidCallback? onLinkTap,
+    VoidCallback? onUnlinkTap,
   }) {
     return MaterialApp(
       home: Scaffold(
@@ -33,6 +34,7 @@ void main() {
           person: person,
           partnerPerson: partnerPerson,
           onLinkTap: onLinkTap ?? () {},
+          onUnlinkTap: onUnlinkTap,
         ),
       ),
     );
@@ -100,6 +102,46 @@ void main() {
 
       await tester.tap(find.byType(ListTile));
       expect(tapped, isFalse);
+    });
+
+    testWidgets('shows Unlink button when person is linked', (tester) async {
+      final person = makePerson(
+        partnerId: 'p2',
+        partnerLinkedAt: DateTime(2026, 4, 10),
+      );
+      final partner = makePerson(id: 'p2', firstName: 'Bob');
+
+      await tester.pumpWidget(buildWidget(
+        person: person,
+        partnerPerson: partner,
+      ));
+
+      expect(find.text('Unlink'), findsOneWidget);
+    });
+
+    testWidgets('does not show Unlink button when person is unlinked',
+        (tester) async {
+      await tester.pumpWidget(buildWidget(person: makePerson()));
+
+      expect(find.text('Unlink'), findsNothing);
+    });
+
+    testWidgets('calls onUnlinkTap when Unlink button pressed', (tester) async {
+      var called = false;
+      final person = makePerson(
+        partnerId: 'p2',
+        partnerLinkedAt: DateTime(2026, 4, 10),
+      );
+      final partner = makePerson(id: 'p2', firstName: 'Bob');
+
+      await tester.pumpWidget(buildWidget(
+        person: person,
+        partnerPerson: partner,
+        onUnlinkTap: () => called = true,
+      ));
+
+      await tester.tap(find.text('Unlink'));
+      expect(called, isTrue);
     });
   });
 }

--- a/test/presentation/persons/couple_separation_dialog_test.dart
+++ b/test/presentation/persons/couple_separation_dialog_test.dart
@@ -1,0 +1,183 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:friendsheet/data/models/catch_up_topic.dart';
+import 'package:friendsheet/data/repositories/catch_up_topic_repository.dart';
+import 'package:friendsheet/presentation/persons/couple_separation_dialog.dart';
+
+void main() {
+  CatchUpTopic makeTopic({
+    String id = 't1',
+    String text = 'Topic text',
+  }) {
+    return CatchUpTopic(
+      id: id,
+      text: text,
+      createdAt: DateTime(2026, 4, 10),
+    );
+  }
+
+  Future<Map<String, TopicRedistributionDecision>?> openDialog(
+    WidgetTester tester, {
+    List<CatchUpTopic> topics = const [],
+    String personAName = 'Anna',
+    String personBName = 'Bob',
+  }) async {
+    Map<String, TopicRedistributionDecision>? result;
+
+    await tester.pumpWidget(MaterialApp(
+      home: Builder(
+        builder: (ctx) => TextButton(
+          onPressed: () async {
+            result = await showDialog<Map<String, TopicRedistributionDecision>>(
+              context: ctx,
+              builder: (_) => CoupleSeparationDialog(
+                personAName: personAName,
+                personBName: personBName,
+                postLinkTopics: topics,
+              ),
+            );
+          },
+          child: const Text('Open'),
+        ),
+      ),
+    ));
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    return result;
+  }
+
+  group('CoupleSeparationDialog', () {
+    testWidgets('shows Redistribute topics title', (tester) async {
+      await openDialog(tester);
+
+      expect(find.text('Redistribute topics'), findsOneWidget);
+    });
+
+    testWidgets('shows topic text for each post-link topic', (tester) async {
+      final topics = [makeTopic(id: 't1', text: 'Topic A')];
+      await openDialog(tester, topics: topics);
+
+      expect(find.text('Topic A'), findsOneWidget);
+    });
+
+    testWidgets('shows ToggleButtons with 4 options per topic', (tester) async {
+      final topics = [makeTopic()];
+      await openDialog(tester, topics: topics);
+
+      expect(find.byType(ToggleButtons), findsOneWidget);
+      // 4 options: personA, Shared, personB, Delete
+      expect(find.text('Anna'), findsOneWidget);
+      expect(find.text('Shared'), findsOneWidget);
+      expect(find.text('Bob'), findsOneWidget);
+      expect(find.text('Delete'), findsOneWidget);
+    });
+
+    testWidgets('returns null when Cancel tapped', (tester) async {
+      Map<String, TopicRedistributionDecision>? result;
+      await tester.pumpWidget(MaterialApp(
+        home: Builder(
+          builder: (ctx) => TextButton(
+            onPressed: () async {
+              result =
+                  await showDialog<Map<String, TopicRedistributionDecision>>(
+                context: ctx,
+                builder: (_) => CoupleSeparationDialog(
+                  personAName: 'Anna',
+                  personBName: 'Bob',
+                  postLinkTopics: [makeTopic()],
+                ),
+              );
+            },
+            child: const Text('Open'),
+          ),
+        ),
+      ));
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(result, isNull);
+    });
+
+    testWidgets('returns decisions map with shared default when Confirm tapped',
+        (tester) async {
+      Map<String, TopicRedistributionDecision>? result;
+      final topic = makeTopic(id: 't1');
+
+      await tester.pumpWidget(MaterialApp(
+        home: Builder(
+          builder: (ctx) => TextButton(
+            onPressed: () async {
+              result =
+                  await showDialog<Map<String, TopicRedistributionDecision>>(
+                context: ctx,
+                builder: (_) => CoupleSeparationDialog(
+                  personAName: 'Anna',
+                  personBName: 'Bob',
+                  postLinkTopics: [topic],
+                ),
+              );
+            },
+            child: const Text('Open'),
+          ),
+        ),
+      ));
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Confirm'));
+      await tester.pumpAndSettle();
+
+      expect(result, isNotNull);
+      expect(result!['t1'], equals(TopicRedistributionDecision.shared));
+    });
+
+    testWidgets('selecting a ToggleButtons option updates decision',
+        (tester) async {
+      Map<String, TopicRedistributionDecision>? result;
+      final topic = makeTopic(id: 't1', text: 'Topic');
+
+      await tester.pumpWidget(MaterialApp(
+        home: Builder(
+          builder: (ctx) => TextButton(
+            onPressed: () async {
+              result =
+                  await showDialog<Map<String, TopicRedistributionDecision>>(
+                context: ctx,
+                builder: (_) => CoupleSeparationDialog(
+                  personAName: 'Anna',
+                  personBName: 'Bob',
+                  postLinkTopics: [topic],
+                ),
+              );
+            },
+            child: const Text('Open'),
+          ),
+        ),
+      ));
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+
+      // Tap 'Delete' (index 3) in the ToggleButtons.
+      await tester.tap(find.text('Delete'));
+      await tester.pump();
+
+      await tester.tap(find.text('Confirm'));
+      await tester.pumpAndSettle();
+
+      expect(result!['t1'], equals(TopicRedistributionDecision.delete));
+    });
+
+    testWidgets('shows no ToggleButtons when postLinkTopics is empty',
+        (tester) async {
+      await openDialog(tester, topics: []);
+
+      expect(find.byType(ToggleButtons), findsNothing);
+    });
+  });
+}

--- a/test/presentation/persons/history_section_test.dart
+++ b/test/presentation/persons/history_section_test.dart
@@ -147,5 +147,19 @@ void main() {
 
       expect(called, isFalse);
     });
+
+    testWidgets('shows badge with count when archived topics present',
+        (tester) async {
+      await tester.pumpWidget(buildSection(archivedTopics: [archivedTopic]));
+
+      expect(find.text('1'), findsOneWidget);
+    });
+
+    testWidgets('does not show badge when archived topics list is empty',
+        (tester) async {
+      await tester.pumpWidget(buildSection(archivedTopics: []));
+
+      expect(find.text('0'), findsNothing);
+    });
   });
 }

--- a/test/presentation/persons/person_detail_provider_test.dart
+++ b/test/presentation/persons/person_detail_provider_test.dart
@@ -187,6 +187,27 @@ void main() {
       });
     });
 
+    group('clearPartner', () {
+      setUp(() async {
+        when(mockMeetingRepository.getMeetingsCountForPerson('u1', 'p1'))
+            .thenAnswer((_) async => 0);
+        await provider.initialize(testPerson);
+      });
+
+      test('clears partnerId and partnerLinkedAt on person', () {
+        provider.setPartner('p2', DateTime(2026, 4, 10));
+        provider.clearPartner();
+
+        expect(provider.person!.partnerId, isNull);
+        expect(provider.person!.partnerLinkedAt, isNull);
+      });
+
+      test('does nothing when person is null', () {
+        // Provider not initialized — person is null.
+        expect(() => provider.clearPartner(), returnsNormally);
+      });
+    });
+
     group('linkFriendAccount', () {
       setUp(() async {
         when(mockMeetingRepository.getMeetingsCountForPerson('u1', 'p1'))


### PR DESCRIPTION
## US-123: Couple Separation Flow

**As a** user **I want to** unlink two persons who are no longer a couple **so that** their topics are redistributed correctly and I maintain accurate social history

### Changes
- `unlinkPartner()` in PersonRepository: batch-clears partnerId/partnerLinkedAt on both persons + Hive write-through
- `TopicRedistributionDecision` enum + `applyRedistribution()` in CatchUpTopicRepository: per-topic personA/shared/personB/delete decisions with text-based partner matching
- `CoupleSeparationDialog` (NEW): 4-state ToggleButtons per post-link topic, defaults to shared, returns decisions map or null
- `CoupleLinkSection`: Unlink button in trailing when linked
- `PersonDetailProvider`: `clearPartner()` for immediate UI refresh
- `PersonDetailScreen`: full separation flow — confirmation, pre-link text-set filtering (fixes merged copy bug), redistribution dialog, partner copy cleanup, delete propagation to partner
- `CatchUpListSection` + `HistorySection`: green badge counters matching child activities style
- 30 new tests (983 total)

Closes #300
