### PR TITLE
302 us 125 friends quest tasks

### DIFF
--- a/.claude/skills/qa/SKILL.md
+++ b/.claude/skills/qa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: qa
 description: Generate and optimize Flutter tests. Use after manual verification.
-allowed-tools: Read, Write, Bash(flutter test:*), Bash(dart format:*), Bash(dart run build_runner:*), Glob, Grep
+allowed-tools: Read, Write, Bash(flutter test:*), Bash(flutter analyze:*), Bash(dart format:*), Bash(dart run build_runner:*), Glob, Grep
 ---
 
 # QA Agent
@@ -35,8 +35,9 @@ c) Coverage audit for a feature"
 
 1. dart run build_runner build --delete-conflicting-outputs
 2. dart format .
-3. flutter test
-4. Update TEST_CASES.md
+3. flutter analyze   ← fix all issues before proceeding
+4. flutter test
+5. Update TEST_CASES.md
 
 ## Output
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Friendsheet are documented here.
 
 ---
 
+### v4.5.12 — US-125: Friends-Quest Tasks (April 20, 2026)
+- ✅ `lib/data/models/friends_quest_task.dart` (MODIFIED) — added `contextLabel: String?` and `sourcePersonId: String?` fields
+- ✅ `lib/data/models/friends_quest_task.freezed.dart` + `friends_quest_task.g.dart` (GENERATED) — build_runner output for updated model
+- ✅ `lib/data/repositories/friends_quest_repository.dart` (MODIFIED) — added `updateQuest(userId, quest)`; fixed Hive deep-cast bug (`jsonDecode(jsonEncode(e))` round-trip in `getAll`)
+- ✅ `lib/presentation/friends_quest/friends_quest_provider.dart` (MODIFIED) — added `CatchUpTopicRepository` + `PersonRepository` deps; new methods: `addTask`, `editTask`, `deleteTask`, `updateParticipants`, `_importTopicsForQuest`; couple-deduplication algorithm; try/finally in `createQuest` to guarantee `_isLoading` reset
+- ✅ `lib/presentation/friends_quest/friends_quest_detail_screen.dart` (NEW) — `FriendsQuestDetailScreen`: AppBar with participant-management icon, FAB for new task, ListView of `QuestTaskTile`; add/edit task dialogs with optional person assignment; participant bottom sheet
+- ✅ `lib/presentation/friends_quest/quest_task_tile.dart` (NEW) — `QuestTaskTile`: read-only checkbox, task text with strikethrough when completed, `names · contextLabel` subtitle, edit/delete icon buttons
+- ✅ `lib/presentation/friends_quest/quest_participants_section.dart` (NEW) — `QuestParticipantsSection`: flat Column widget for use in bottom sheet; remove participant + add-person search dialog
+- ✅ `lib/presentation/friends_quest/friends_quest_list_screen.dart` (MODIFIED) — quest `onTap` navigates to `FriendsQuestDetailScreen` via `ChangeNotifierProvider.value`; `loadQuests` called on return
+- ✅ `test/data/repositories/friends_quest_repository_test.dart` (MODIFIED) — +2 tests: `updateQuest` replaces in place, nested task round-trip serialization
+- ✅ `test/presentation/friends_quest/friends_quest_provider_test.dart` (MODIFIED) — +7 tests: `addTask` (with/without assignees), `deleteTask`, `editTask` (with/without source), `updateParticipants`, `createQuest` with import
+- ✅ `test/presentation/friends_quest/quest_task_tile_test.dart` (NEW) — 5 widget tests: text, subtitle names, contextLabel, callbacks, strikethrough
+- ✅ `test/presentation/screens/home_screen_test.dart` + `home_screen_test.mocks.dart` (MODIFIED) — updated to pass `CatchUpTopicRepository` mock to `FriendsQuestProvider`
+- ✅ 1015 Flutter tests passing (+14 new tests)
+
+---
+
 ### v4.5.11 — US-124: Friends-Quest List & Creation (April 20, 2026)
 - ✅ `lib/data/models/friends_quest.dart` (NEW) — `FriendsQuest` Freezed model: `id`, `name`, `participantIds`, `linkedMeetingId?`, `createdAt`, `isCompleted`, `tasks` (list of `FriendsQuestTask`)
 - ✅ `lib/data/models/friends_quest_task.dart` (NEW) — `FriendsQuestTask` Freezed model: `id`, `text`, `sourceTopicId?`, `assignedPersonIds`, `isCompleted`

--- a/MULTI_AGENT_ARCHITECTURE.md
+++ b/MULTI_AGENT_ARCHITECTURE.md
@@ -567,8 +567,9 @@ c) Coverage audit for a feature"
 
 1. dart run build_runner build --delete-conflicting-outputs
 2. dart format .
-3. flutter test
-4. Update TEST_CASES.md
+3. flutter analyze   ← fix all issues before proceeding
+4. flutter test
+5. Update TEST_CASES.md
 
 ## Output
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ flutter format --set-exit-if-changed .
 
 **Current Test Status:**
 ```
-✅ All tests passing (1001)
+✅ All tests passing (1015)
 ✅ Code formatted correctly
 ✅ Firebase connected successfully
 ✅ CI/CD pipeline operational
@@ -174,16 +174,14 @@ Project Link: [https://github.com/aleksanderginalski/Friendsheet-App](https://gi
 
 Full version history is available in [CHANGELOG.md](CHANGELOG.md).
 
-### Latest: v4.5.11 — US-124: Friends-Quest List & Creation (April 20, 2026)
-- ✅ `FriendsQuest` + `FriendsQuestTask` Freezed models (NEW) — Hive-serialized, device-local only
-- ✅ `FriendsQuestRepository` (NEW) — Hive CRUD: create/getAll/delete; persists across logout/login
-- ✅ `HiveService` (MODIFIED) — `friends_quests` box; intentionally excluded from `clearUserData()`
-- ✅ `FriendsQuestProvider` (NEW) — ChangeNotifier: load/create/delete, exposes `activeQuests`
-- ✅ `FriendsQuestListScreen` (NEW) — list with participant count, pending task count, delete confirmation
-- ✅ `CreateQuestDialog` (NEW) — name field + participant multi-picker with search filter
-- ✅ `FriendsQuestSummaryWidget` (NEW) — home screen card: "N active quest(s)" + "View all →"
-- ✅ `MainScreen` + `HomeScreen` (MODIFIED) — provider wired at MainScreen level; drawer tile; Consumer on home
-- ✅ 18 new tests (1001 total)
+### Latest: v4.5.12 — US-125: Friends-Quest Tasks (April 20, 2026)
+- ✅ `FriendsQuestTask` (MODIFIED) — `contextLabel` and `sourcePersonId` fields added
+- ✅ `FriendsQuestRepository` (MODIFIED) — `updateQuest()`; deep Hive cast fix via json round-trip
+- ✅ `FriendsQuestProvider` (MODIFIED) — `addTask`, `editTask`, `deleteTask`, `updateParticipants`, `_importTopicsForQuest` with couple-deduplication
+- ✅ `FriendsQuestDetailScreen` (NEW) — task list, add/edit dialogs, participant management bottom sheet
+- ✅ `QuestTaskTile` (NEW) — task row with read-only checkbox, subtitle, edit/delete actions
+- ✅ `QuestParticipantsSection` (NEW) — participant management widget for bottom sheet
+- ✅ 14 new tests (1015 total)
 
 See [CHANGELOG.md](CHANGELOG.md) for all previous versions.
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -4833,7 +4833,7 @@ Firestore SDK on Flutter mobile has built-in offline persistence enabled by defa
 **Story Points:** 8
 **Priority:** P2
 **Labels:** `friends-quest`, `tasks`, `sync`
-**Status:** 📋 Planned
+**Status:** 🔄 In Progress
 **Feature:** FEATURE-032: Friends-Quest
 
 **Acceptance Criteria:**

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -4833,29 +4833,29 @@ Firestore SDK on Flutter mobile has built-in offline persistence enabled by defa
 **Story Points:** 8
 **Priority:** P2
 **Labels:** `friends-quest`, `tasks`, `sync`
-**Status:** 🔄 In Progress
+**Status:** ✅ COMPLETED
 **Feature:** FEATURE-032: Friends-Quest
 
 **Acceptance Criteria:**
-- [ ] On quest creation: active Catch-up Topics for all participants auto-imported as tasks
-- [ ] Deduplication: if two participants are linked as a couple and share a topic, it appears only once
-- [ ] Edge case: if only one person of a couple is in the quest, their shared topics are still visible (couple treated as unit for topic ownership)
-- [ ] User can manually add a task (text + optional person assignment from participants list)
+- [x] On quest creation: active Catch-up Topics for all participants auto-imported as tasks
+- [x] Deduplication: if two participants are linked as a couple and share a topic, it appears only once
+- [x] Edge case: if only one person of a couple is in the quest, their shared topics are still visible (couple treated as unit for topic ownership)
+- [x] User can manually add a task (text + optional person assignment from participants list)
   - If person assigned: task also saved as a new Catch-up Topic for that person
-- [ ] Edit task with `sourceTopicId`: edit propagates to original Catch-up Topic (and to partner if couple-linked — both updated)
-- [ ] Edit task without `sourceTopicId`: local edit only
-- [ ] Delete task with `sourceTopicId`: original Catch-up Topic is NOT deleted
-- [ ] Delete task without `sourceTopicId`: deleted locally
-- [ ] User can manage quest participants (add/remove); catch-up topics re-synced after change
-- [ ] `flutter analyze` clean, `flutter test` pass
+- [x] Edit task with `sourceTopicId`: edit propagates to original Catch-up Topic (and to partner if couple-linked — both updated)
+- [x] Edit task without `sourceTopicId`: local edit only
+- [x] Delete task with `sourceTopicId`: original Catch-up Topic is NOT deleted
+- [x] Delete task without `sourceTopicId`: deleted locally
+- [x] User can manage quest participants (add/remove); catch-up topics re-synced after change
+- [x] `flutter analyze` clean, `flutter test` pass
 
 **Tasks:**
-- [ ] **TASK-125.1:** Implement `importTopicsAsTasksForQuest(questId)` — loads active topics for all participants, applies couple-deduplication, creates `FriendsQuestTask` entries — 3h
-- [ ] **TASK-125.2:** Implement `addTask(questId, text, personIds)` — creates task + optional Catch-up Topic propagation — 1.5h
-- [ ] **TASK-125.3:** Implement `editTask(questId, taskId, newText)` — propagates to `sourceTopicId` if present (and partner if couple-linked) — 2h
-- [ ] **TASK-125.4:** Implement `deleteTask(questId, taskId)` — local removal only; never touches `sourceTopicId` — 0.5h
-- [ ] **TASK-125.5:** Implement `updateParticipants(questId, personIds)` — re-imports topics after participant change — 1h
-- [ ] **TASK-125.6:** Build `FriendsQuestDetailScreen` — task list, add/edit/delete UI, participant management — 3h
+- [x] **TASK-125.1:** Implement `importTopicsAsTasksForQuest(questId)` — loads active topics for all participants, applies couple-deduplication, creates `FriendsQuestTask` entries — 3h
+- [x] **TASK-125.2:** Implement `addTask(questId, text, personIds)` — creates task + optional Catch-up Topic propagation — 1.5h
+- [x] **TASK-125.3:** Implement `editTask(questId, taskId, newText)` — propagates to `sourceTopicId` if present (and partner if couple-linked) — 2h
+- [x] **TASK-125.4:** Implement `deleteTask(questId, taskId)` — local removal only; never touches `sourceTopicId` — 0.5h
+- [x] **TASK-125.5:** Implement `updateParticipants(questId, personIds)` — re-imports topics after participant change — 1h
+- [x] **TASK-125.6:** Build `FriendsQuestDetailScreen` — task list, add/edit/delete UI, participant management — 3h
 
 **Dependencies:** US-121, US-122, US-124
 **Blocks:** US-126

--- a/docs/TEST_CASES.md
+++ b/docs/TEST_CASES.md
@@ -2024,3 +2024,34 @@ Run after every release or hotfix:
 | UT-124-017 | tapping View all calls onViewAll | callback invoked |
 | UT-124-018 | tapping tile also calls onViewAll | callback invoked via ListTile |
 
+## US-125 — Friends-Quest Tasks
+
+### Automated tests — `test/data/repositories/friends_quest_repository_test.dart` (additions)
+
+| ID | Test name | Expected |
+|----|-----------|---------|
+| UT-125-001 | updateQuest replaces matching quest, others unchanged | task saved, other quest unchanged |
+| UT-125-002 | updateQuest persists nested tasks (round-trip serialization) | all task fields preserved after re-read |
+
+### Automated tests — `test/presentation/friends_quest/friends_quest_provider_test.dart` (additions)
+
+| ID | Test name | Expected |
+|----|-----------|---------|
+| UT-125-003 | addTask without assignees adds task and skips catchup | task saved, catchup.add not called |
+| UT-125-004 | addTask with assignees calls catchup.add and sets source fields | catchup.add × 2, sourceTopicId and sourcePersonId set |
+| UT-125-005 | deleteTask removes task from quest | updateQuest called with empty tasks |
+| UT-125-006 | editTask without sourceTopicId updates text only, no catchup call | text updated, catchup.update not called |
+| UT-125-007 | editTask with sourceTopicId calls catchup.update | catchup.update called with new text |
+| UT-125-008 | updateParticipants keeps manual tasks and drops imported tasks | first updateQuest call has only manual task, participantIds updated |
+| UT-125-009 | createQuest with participants imports topics as tasks | updateQuest called with imported task, isLoading reset to false |
+
+### Automated tests — `test/presentation/friends_quest/quest_task_tile_test.dart` (NEW)
+
+| ID | Test name | Expected |
+|----|-----------|---------|
+| UT-125-010 | shows task text and read-only checkbox | text visible, checkbox.onChanged is null |
+| UT-125-011 | shows assigned person names in subtitle | 'Alice, Bob' visible |
+| UT-125-012 | shows names and contextLabel combined in subtitle | 'Alice · Dinner' visible |
+| UT-125-013 | edit and delete buttons trigger callbacks | both callbacks invoked |
+| UT-125-014 | completed task shows strikethrough text | TextDecoration.lineThrough on text |
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -750,7 +750,7 @@ Deletion of a bonus removes the corresponding notes entry.
 
 **Data models (Hive):**
 - `FriendsQuest`: id, name, participantIds, linkedMeetingId?, createdAt, isCompleted
-- `FriendsQuestTask`: id, text, sourceTopicId?, assignedPersonIds, isCompleted
+- `FriendsQuestTask`: id, text, contextLabel?, sourceTopicId?, sourcePersonId?, assignedPersonIds, isCompleted
 
 **Cardinality:** 1 quest : 1 meeting (max); 1 meeting : N quests (allowed).
 
@@ -775,17 +775,26 @@ Deletion of a bonus removes the corresponding notes entry.
 
 ---
 
-### FEATURE-032 — Friends-Quest Architecture (US-124)
+### FEATURE-032 — Friends-Quest Architecture (US-124 + US-125)
 
 **Data storage:** Hive only (`friends_quests` box). No Firestore. Quest data is device-local and persists across logout/login cycles.
 
 **Key design decision:** `clearUserData()` in `HiveService` intentionally does NOT clear the `friends_quests` box. Quests are local planning tools — they are not tied to a Firebase UID and should survive authentication changes on the same device.
 
-**Data layout:** Key = `userId`, Value = `List<Map>` (JSON-serialized list of `FriendsQuest` objects). All CRUD operates on the full list per user — read, mutate, write-back.
+**Data layout:** Key = `userId`, Value = `List<Map>` (JSON-serialized list of `FriendsQuest` objects). All CRUD operates on the full list per user — read, mutate, write-back. Nested `tasks` list uses `jsonDecode(jsonEncode(e))` deep round-trip on read to handle Hive's `Map<dynamic, dynamic>` for nested objects.
 
-**Provider ownership:** `FriendsQuestProvider` is instantiated in `_MainScreenState` (same level as `BuddyWidgetProvider`). Both `HomeScreen` (summary widget) and `FriendsQuestListScreen` access it via `ChangeNotifierProvider.value` at call-site — follows Navigator.push Provider Scope Rule.
+**Provider ownership:** `FriendsQuestProvider` is instantiated in `_MainScreenState`. `FriendsQuestListScreen` and `FriendsQuestDetailScreen` access it via `ChangeNotifierProvider.value` at call-site — follows Navigator.push Provider Scope Rule.
 
 **Persistence across logout:** `FriendsQuestRepository.getAll(userId)` is keyed by userId string. If the device user logs in as a different account, a different key is used — data is isolated per userId string without being cleared on logout.
+
+**Topic import algorithm (`_importTopicsForQuest`):**
+1. Load `Person` records for all `participantIds` from Firestore.
+2. Detect couple pairs: both `A.partnerId == B` AND B is in `participantIds` — deduplicate shared topics by case-insensitive text trim.
+3. For couple pairs: A-topics matched with B-topics → one task with `assignedPersonIds: [A, B]`; unmatched topics → one task for each owner.
+4. For solo participants (not part of any couple pair in this quest): one task per topic.
+5. `sourceTopicId` + `sourcePersonId` set on every imported task for edit-propagation tracking.
+
+**Edit propagation:** `editTask` with `sourceTopicId` updates the originating `CatchUpTopic`, then loads source person's `partnerId` and updates partner's matching topic (by case-insensitive text trim) regardless of quest participation.
 
 ---
 

--- a/lib/data/models/friends_quest_task.dart
+++ b/lib/data/models/friends_quest_task.dart
@@ -8,7 +8,9 @@ class FriendsQuestTask with _$FriendsQuestTask {
   const factory FriendsQuestTask({
     required String id,
     required String text,
+    String? contextLabel,
     String? sourceTopicId,
+    String? sourcePersonId,
     @Default([]) List<String> assignedPersonIds,
     @Default(false) bool isCompleted,
   }) = _FriendsQuestTask;

--- a/lib/data/models/friends_quest_task.freezed.dart
+++ b/lib/data/models/friends_quest_task.freezed.dart
@@ -22,7 +22,9 @@ FriendsQuestTask _$FriendsQuestTaskFromJson(Map<String, dynamic> json) {
 mixin _$FriendsQuestTask {
   String get id => throw _privateConstructorUsedError;
   String get text => throw _privateConstructorUsedError;
+  String? get contextLabel => throw _privateConstructorUsedError;
   String? get sourceTopicId => throw _privateConstructorUsedError;
+  String? get sourcePersonId => throw _privateConstructorUsedError;
   List<String> get assignedPersonIds => throw _privateConstructorUsedError;
   bool get isCompleted => throw _privateConstructorUsedError;
 
@@ -45,7 +47,9 @@ abstract class $FriendsQuestTaskCopyWith<$Res> {
   $Res call(
       {String id,
       String text,
+      String? contextLabel,
       String? sourceTopicId,
+      String? sourcePersonId,
       List<String> assignedPersonIds,
       bool isCompleted});
 }
@@ -67,7 +71,9 @@ class _$FriendsQuestTaskCopyWithImpl<$Res, $Val extends FriendsQuestTask>
   $Res call({
     Object? id = null,
     Object? text = null,
+    Object? contextLabel = freezed,
     Object? sourceTopicId = freezed,
+    Object? sourcePersonId = freezed,
     Object? assignedPersonIds = null,
     Object? isCompleted = null,
   }) {
@@ -80,9 +86,17 @@ class _$FriendsQuestTaskCopyWithImpl<$Res, $Val extends FriendsQuestTask>
           ? _value.text
           : text // ignore: cast_nullable_to_non_nullable
               as String,
+      contextLabel: freezed == contextLabel
+          ? _value.contextLabel
+          : contextLabel // ignore: cast_nullable_to_non_nullable
+              as String?,
       sourceTopicId: freezed == sourceTopicId
           ? _value.sourceTopicId
           : sourceTopicId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      sourcePersonId: freezed == sourcePersonId
+          ? _value.sourcePersonId
+          : sourcePersonId // ignore: cast_nullable_to_non_nullable
               as String?,
       assignedPersonIds: null == assignedPersonIds
           ? _value.assignedPersonIds
@@ -107,7 +121,9 @@ abstract class _$$FriendsQuestTaskImplCopyWith<$Res>
   $Res call(
       {String id,
       String text,
+      String? contextLabel,
       String? sourceTopicId,
+      String? sourcePersonId,
       List<String> assignedPersonIds,
       bool isCompleted});
 }
@@ -127,7 +143,9 @@ class __$$FriendsQuestTaskImplCopyWithImpl<$Res>
   $Res call({
     Object? id = null,
     Object? text = null,
+    Object? contextLabel = freezed,
     Object? sourceTopicId = freezed,
+    Object? sourcePersonId = freezed,
     Object? assignedPersonIds = null,
     Object? isCompleted = null,
   }) {
@@ -140,9 +158,17 @@ class __$$FriendsQuestTaskImplCopyWithImpl<$Res>
           ? _value.text
           : text // ignore: cast_nullable_to_non_nullable
               as String,
+      contextLabel: freezed == contextLabel
+          ? _value.contextLabel
+          : contextLabel // ignore: cast_nullable_to_non_nullable
+              as String?,
       sourceTopicId: freezed == sourceTopicId
           ? _value.sourceTopicId
           : sourceTopicId // ignore: cast_nullable_to_non_nullable
+              as String?,
+      sourcePersonId: freezed == sourcePersonId
+          ? _value.sourcePersonId
+          : sourcePersonId // ignore: cast_nullable_to_non_nullable
               as String?,
       assignedPersonIds: null == assignedPersonIds
           ? _value._assignedPersonIds
@@ -162,7 +188,9 @@ class _$FriendsQuestTaskImpl implements _FriendsQuestTask {
   const _$FriendsQuestTaskImpl(
       {required this.id,
       required this.text,
+      this.contextLabel,
       this.sourceTopicId,
+      this.sourcePersonId,
       final List<String> assignedPersonIds = const [],
       this.isCompleted = false})
       : _assignedPersonIds = assignedPersonIds;
@@ -175,7 +203,11 @@ class _$FriendsQuestTaskImpl implements _FriendsQuestTask {
   @override
   final String text;
   @override
+  final String? contextLabel;
+  @override
   final String? sourceTopicId;
+  @override
+  final String? sourcePersonId;
   final List<String> _assignedPersonIds;
   @override
   @JsonKey()
@@ -192,7 +224,7 @@ class _$FriendsQuestTaskImpl implements _FriendsQuestTask {
 
   @override
   String toString() {
-    return 'FriendsQuestTask(id: $id, text: $text, sourceTopicId: $sourceTopicId, assignedPersonIds: $assignedPersonIds, isCompleted: $isCompleted)';
+    return 'FriendsQuestTask(id: $id, text: $text, contextLabel: $contextLabel, sourceTopicId: $sourceTopicId, sourcePersonId: $sourcePersonId, assignedPersonIds: $assignedPersonIds, isCompleted: $isCompleted)';
   }
 
   @override
@@ -202,8 +234,12 @@ class _$FriendsQuestTaskImpl implements _FriendsQuestTask {
             other is _$FriendsQuestTaskImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.text, text) || other.text == text) &&
+            (identical(other.contextLabel, contextLabel) ||
+                other.contextLabel == contextLabel) &&
             (identical(other.sourceTopicId, sourceTopicId) ||
                 other.sourceTopicId == sourceTopicId) &&
+            (identical(other.sourcePersonId, sourcePersonId) ||
+                other.sourcePersonId == sourcePersonId) &&
             const DeepCollectionEquality()
                 .equals(other._assignedPersonIds, _assignedPersonIds) &&
             (identical(other.isCompleted, isCompleted) ||
@@ -212,8 +248,15 @@ class _$FriendsQuestTaskImpl implements _FriendsQuestTask {
 
   @JsonKey(includeFromJson: false, includeToJson: false)
   @override
-  int get hashCode => Object.hash(runtimeType, id, text, sourceTopicId,
-      const DeepCollectionEquality().hash(_assignedPersonIds), isCompleted);
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      text,
+      contextLabel,
+      sourceTopicId,
+      sourcePersonId,
+      const DeepCollectionEquality().hash(_assignedPersonIds),
+      isCompleted);
 
   /// Create a copy of FriendsQuestTask
   /// with the given fields replaced by the non-null parameter values.
@@ -236,7 +279,9 @@ abstract class _FriendsQuestTask implements FriendsQuestTask {
   const factory _FriendsQuestTask(
       {required final String id,
       required final String text,
+      final String? contextLabel,
       final String? sourceTopicId,
+      final String? sourcePersonId,
       final List<String> assignedPersonIds,
       final bool isCompleted}) = _$FriendsQuestTaskImpl;
 
@@ -248,7 +293,11 @@ abstract class _FriendsQuestTask implements FriendsQuestTask {
   @override
   String get text;
   @override
+  String? get contextLabel;
+  @override
   String? get sourceTopicId;
+  @override
+  String? get sourcePersonId;
   @override
   List<String> get assignedPersonIds;
   @override

--- a/lib/data/models/friends_quest_task.g.dart
+++ b/lib/data/models/friends_quest_task.g.dart
@@ -15,7 +15,10 @@ _$FriendsQuestTaskImpl _$$FriendsQuestTaskImplFromJson(
         final val = _$FriendsQuestTaskImpl(
           id: $checkedConvert('id', (v) => v as String),
           text: $checkedConvert('text', (v) => v as String),
+          contextLabel: $checkedConvert('contextLabel', (v) => v as String?),
           sourceTopicId: $checkedConvert('sourceTopicId', (v) => v as String?),
+          sourcePersonId:
+              $checkedConvert('sourcePersonId', (v) => v as String?),
           assignedPersonIds: $checkedConvert(
               'assignedPersonIds',
               (v) =>
@@ -33,7 +36,9 @@ Map<String, dynamic> _$$FriendsQuestTaskImplToJson(
     <String, dynamic>{
       'id': instance.id,
       'text': instance.text,
+      'contextLabel': instance.contextLabel,
       'sourceTopicId': instance.sourceTopicId,
+      'sourcePersonId': instance.sourcePersonId,
       'assignedPersonIds': instance.assignedPersonIds,
       'isCompleted': instance.isCompleted,
     };

--- a/lib/data/repositories/friends_quest_repository.dart
+++ b/lib/data/repositories/friends_quest_repository.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:uuid/uuid.dart';
 
@@ -14,7 +16,9 @@ class FriendsQuestRepository {
     if (raw == null) return [];
     return (raw as List<dynamic>)
         .map(
-          (e) => FriendsQuest.fromJson(Map<String, dynamic>.from(e as Map)),
+          (e) => FriendsQuest.fromJson(
+            Map<String, dynamic>.from(jsonDecode(jsonEncode(e)) as Map),
+          ),
         )
         .toList();
   }
@@ -41,6 +45,12 @@ class FriendsQuestRepository {
 
   Future<void> delete(String userId, String questId) async {
     final updated = getAll(userId).where((q) => q.id != questId).toList();
+    await _save(userId, updated);
+  }
+
+  Future<void> updateQuest(String userId, FriendsQuest quest) async {
+    final updated =
+        getAll(userId).map((q) => q.id == quest.id ? quest : q).toList();
     await _save(userId, updated);
   }
 }

--- a/lib/presentation/friends_quest/friends_quest_detail_screen.dart
+++ b/lib/presentation/friends_quest/friends_quest_detail_screen.dart
@@ -32,11 +32,9 @@ class _FriendsQuestDetailScreenState extends State<FriendsQuestDetailScreen> {
   }
 
   Future<void> _loadPersons() async {
-    final quest = context
-        .read<FriendsQuestProvider>()
-        .quests
-        .firstWhere((q) => q.id == widget.questId,
-            orElse: () => throw StateError('Quest not found'));
+    final quest = context.read<FriendsQuestProvider>().quests.firstWhere(
+        (q) => q.id == widget.questId,
+        orElse: () => throw StateError('Quest not found'));
     final persons =
         await PersonRepository().getPersonsByIds(quest.participantIds, _userId);
     if (mounted) {

--- a/lib/presentation/friends_quest/friends_quest_detail_screen.dart
+++ b/lib/presentation/friends_quest/friends_quest_detail_screen.dart
@@ -1,0 +1,268 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../data/models/friends_quest_task.dart';
+import '../../data/models/person.dart';
+import '../../data/repositories/person_repository.dart';
+import '../../data/services/auth_service.dart';
+import 'friends_quest_provider.dart';
+import 'quest_participants_section.dart';
+import 'quest_task_tile.dart';
+
+class FriendsQuestDetailScreen extends StatefulWidget {
+  final String questId;
+
+  const FriendsQuestDetailScreen({super.key, required this.questId});
+
+  @override
+  State<FriendsQuestDetailScreen> createState() =>
+      _FriendsQuestDetailScreenState();
+}
+
+class _FriendsQuestDetailScreenState extends State<FriendsQuestDetailScreen> {
+  late final String _userId;
+  Map<String, Person> _personMap = {};
+  bool _loadingPersons = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _userId = AuthService().currentUserId ?? '';
+    WidgetsBinding.instance.addPostFrameCallback((_) => _loadPersons());
+  }
+
+  Future<void> _loadPersons() async {
+    final quest = context
+        .read<FriendsQuestProvider>()
+        .quests
+        .firstWhere((q) => q.id == widget.questId,
+            orElse: () => throw StateError('Quest not found'));
+    final persons =
+        await PersonRepository().getPersonsByIds(quest.participantIds, _userId);
+    if (mounted) {
+      setState(() {
+        _personMap = {for (final p in persons) p.id: p};
+        _loadingPersons = false;
+      });
+    }
+  }
+
+  Future<void> _reloadPersons(List<String> ids) async {
+    final persons = await PersonRepository().getPersonsByIds(ids, _userId);
+    if (mounted) {
+      setState(() => _personMap = {for (final p in persons) p.id: p});
+    }
+  }
+
+  void _showParticipantsSheet(
+      FriendsQuestProvider provider, List<String> participantIds) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (_) => Padding(
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        child: QuestParticipantsSection(
+          participantIds: participantIds,
+          personMap: _personMap,
+          userId: _userId,
+          onParticipantsChanged: (newIds) async {
+            await provider.updateParticipants(_userId, widget.questId, newIds);
+            await _reloadPersons(newIds);
+            if (mounted) Navigator.pop(context);
+          },
+        ),
+      ),
+    );
+  }
+
+  void _showAddTaskDialog(
+      FriendsQuestProvider provider, List<String> participantIds) {
+    final textController = TextEditingController();
+    final selectedIds = <String>{};
+    var adding = false;
+
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setDialog) => AlertDialog(
+          title: const Text('New task'),
+          content: SizedBox(
+            width: double.maxFinite,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                TextField(
+                  controller: textController,
+                  autofocus: true,
+                  maxLength: 200,
+                  decoration: const InputDecoration(labelText: 'Task text'),
+                  onChanged: (_) => setDialog(() {}),
+                ),
+                if (participantIds.isNotEmpty) ...[
+                  const SizedBox(height: 8),
+                  const Text('Assign to (optional)',
+                      style: TextStyle(fontWeight: FontWeight.w600)),
+                  ConstrainedBox(
+                    constraints: const BoxConstraints(maxHeight: 200),
+                    child: ListView(
+                      shrinkWrap: true,
+                      children: participantIds.map((id) {
+                        final name = _personMap[id]?.fullName ?? id;
+                        return CheckboxListTile(
+                          dense: true,
+                          title: Text(name),
+                          value: selectedIds.contains(id),
+                          onChanged: (v) => setDialog(() {
+                            if (v == true) {
+                              selectedIds.add(id);
+                            } else {
+                              selectedIds.remove(id);
+                            }
+                          }),
+                        );
+                      }).toList(),
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx),
+              child: const Text('CANCEL'),
+            ),
+            TextButton(
+              onPressed: textController.text.trim().isEmpty || adding
+                  ? null
+                  : () async {
+                      setDialog(() => adding = true);
+                      await provider.addTask(
+                        _userId,
+                        widget.questId,
+                        textController.text.trim(),
+                        selectedIds.toList(),
+                      );
+                      if (ctx.mounted) Navigator.pop(ctx);
+                    },
+              child: adding
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('ADD'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showEditTaskDialog(
+      FriendsQuestProvider provider, FriendsQuestTask task) {
+    final textController = TextEditingController(text: task.text);
+    var saving = false;
+
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => StatefulBuilder(
+        builder: (ctx, setDialog) => AlertDialog(
+          title: const Text('Edit task'),
+          content: TextField(
+            controller: textController,
+            autofocus: true,
+            maxLength: 200,
+            decoration: const InputDecoration(labelText: 'Task text'),
+            onChanged: (_) => setDialog(() {}),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx),
+              child: const Text('CANCEL'),
+            ),
+            TextButton(
+              onPressed: textController.text.trim().isEmpty || saving
+                  ? null
+                  : () async {
+                      setDialog(() => saving = true);
+                      await provider.editTask(
+                        _userId,
+                        widget.questId,
+                        task.id,
+                        textController.text.trim(),
+                      );
+                      if (ctx.mounted) Navigator.pop(ctx);
+                    },
+              child: saving
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Text('SAVE'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<FriendsQuestProvider>();
+    final questIndex =
+        provider.quests.indexWhere((q) => q.id == widget.questId);
+    if (questIndex == -1) {
+      return const Scaffold(body: Center(child: Text('Quest not found.')));
+    }
+    final quest = provider.quests[questIndex];
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(quest.name, style: const TextStyle(color: Colors.white)),
+        backgroundColor: const Color(0xFF4CAF50),
+        foregroundColor: Colors.white,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.people_outline),
+            tooltip: 'Manage participants',
+            onPressed: _loadingPersons
+                ? null
+                : () => _showParticipantsSheet(provider, quest.participantIds),
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _showAddTaskDialog(provider, quest.participantIds),
+        backgroundColor: const Color(0xFF4CAF50),
+        foregroundColor: Colors.white,
+        child: const Icon(Icons.add),
+      ),
+      body: _loadingPersons
+          ? const Center(child: CircularProgressIndicator())
+          : quest.tasks.isEmpty
+              ? const Center(
+                  child: Text(
+                    'No tasks yet. Add one with the + button.',
+                    style: TextStyle(color: Colors.grey),
+                    textAlign: TextAlign.center,
+                  ),
+                )
+              : ListView.builder(
+                  itemCount: quest.tasks.length,
+                  itemBuilder: (_, i) {
+                    final task = quest.tasks[i];
+                    return QuestTaskTile(
+                      task: task,
+                      personMap: _personMap,
+                      onEdit: () => _showEditTaskDialog(provider, task),
+                      onDelete: () =>
+                          provider.deleteTask(_userId, widget.questId, task.id),
+                    );
+                  },
+                ),
+    );
+  }
+}

--- a/lib/presentation/friends_quest/friends_quest_list_screen.dart
+++ b/lib/presentation/friends_quest/friends_quest_list_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import '../../data/services/auth_service.dart';
 import 'create_quest_dialog.dart';
+import 'friends_quest_detail_screen.dart';
 import 'friends_quest_provider.dart';
 
 class FriendsQuestListScreen extends StatefulWidget {
@@ -64,6 +65,21 @@ class _FriendsQuestListScreenState extends State<FriendsQuestListScreen> {
     );
   }
 
+  void _openDetail(BuildContext context, FriendsQuestProvider provider, String questId) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => ChangeNotifierProvider.value(
+          value: provider,
+          child: FriendsQuestDetailScreen(questId: questId),
+        ),
+      ),
+    ).then((_) {
+      if (!mounted) return;
+      provider.loadQuests(_userId);
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final provider = context.watch<FriendsQuestProvider>();
@@ -95,18 +111,20 @@ class _FriendsQuestListScreenState extends State<FriendsQuestListScreen> {
               itemCount: quests.length,
               itemBuilder: (context, index) {
                 final quest = quests[index];
-                final pending = quest.tasks.where((t) => !t.isCompleted).length;
+                final pending =
+                    quest.tasks.where((t) => !t.isCompleted).length;
                 final participantCount = quest.participantIds.length;
                 return ListTile(
                   title: Text(quest.name),
                   subtitle: Text('$participantCount participants'),
+                  onTap: () => _openDetail(context, provider, quest.id),
                   trailing: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       Text(
                         '$pending pending',
-                        style:
-                            const TextStyle(fontSize: 12, color: Colors.grey),
+                        style: const TextStyle(
+                            fontSize: 12, color: Colors.grey),
                       ),
                       IconButton(
                         icon: const Icon(Icons.delete_outline),

--- a/lib/presentation/friends_quest/friends_quest_list_screen.dart
+++ b/lib/presentation/friends_quest/friends_quest_list_screen.dart
@@ -65,7 +65,8 @@ class _FriendsQuestListScreenState extends State<FriendsQuestListScreen> {
     );
   }
 
-  void _openDetail(BuildContext context, FriendsQuestProvider provider, String questId) {
+  void _openDetail(
+      BuildContext context, FriendsQuestProvider provider, String questId) {
     Navigator.push(
       context,
       MaterialPageRoute(
@@ -111,8 +112,7 @@ class _FriendsQuestListScreenState extends State<FriendsQuestListScreen> {
               itemCount: quests.length,
               itemBuilder: (context, index) {
                 final quest = quests[index];
-                final pending =
-                    quest.tasks.where((t) => !t.isCompleted).length;
+                final pending = quest.tasks.where((t) => !t.isCompleted).length;
                 final participantCount = quest.participantIds.length;
                 return ListTile(
                   title: Text(quest.name),
@@ -123,8 +123,8 @@ class _FriendsQuestListScreenState extends State<FriendsQuestListScreen> {
                     children: [
                       Text(
                         '$pending pending',
-                        style: const TextStyle(
-                            fontSize: 12, color: Colors.grey),
+                        style:
+                            const TextStyle(fontSize: 12, color: Colors.grey),
                       ),
                       IconButton(
                         icon: const Icon(Icons.delete_outline),

--- a/lib/presentation/friends_quest/friends_quest_provider.dart
+++ b/lib/presentation/friends_quest/friends_quest_provider.dart
@@ -1,16 +1,30 @@
 import 'package:flutter/foundation.dart';
+import 'package:uuid/uuid.dart';
 
+import '../../data/models/catch_up_topic.dart';
 import '../../data/models/friends_quest.dart';
+import '../../data/models/friends_quest_task.dart';
+import '../../data/repositories/catch_up_topic_repository.dart';
 import '../../data/repositories/friends_quest_repository.dart';
+import '../../data/repositories/person_repository.dart';
 
 class FriendsQuestProvider extends ChangeNotifier {
   final FriendsQuestRepository _repository;
+  final CatchUpTopicRepository _catchUpRepo;
+  final PersonRepository _personRepo;
+
+  static const _uuid = Uuid();
 
   List<FriendsQuest> _quests = [];
   bool _isLoading = false;
 
-  FriendsQuestProvider({FriendsQuestRepository? repository})
-      : _repository = repository ?? FriendsQuestRepository();
+  FriendsQuestProvider({
+    FriendsQuestRepository? repository,
+    CatchUpTopicRepository? catchUpRepo,
+    PersonRepository? personRepo,
+  })  : _repository = repository ?? FriendsQuestRepository(),
+        _catchUpRepo = catchUpRepo ?? CatchUpTopicRepository(),
+        _personRepo = personRepo ?? PersonRepository();
 
   List<FriendsQuest> get quests => _quests;
   List<FriendsQuest> get activeQuests =>
@@ -29,14 +43,231 @@ class FriendsQuestProvider extends ChangeNotifier {
   ) async {
     _isLoading = true;
     notifyListeners();
-    await _repository.create(userId, name, participantIds);
-    _quests = _repository.getAll(userId);
-    _isLoading = false;
-    notifyListeners();
+    try {
+      final quest = await _repository.create(userId, name, participantIds);
+      _quests = _repository.getAll(userId);
+      if (participantIds.isNotEmpty) {
+        try {
+          await _importTopicsForQuest(userId, quest.id);
+        } catch (_) {
+          // Import failure must not block quest creation.
+          _quests = _repository.getAll(userId);
+          notifyListeners();
+        }
+      }
+      _quests = _repository.getAll(userId);
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
   }
 
   Future<void> deleteQuest(String userId, String questId) async {
     await _repository.delete(userId, questId);
+    _quests = _repository.getAll(userId);
+    notifyListeners();
+  }
+
+  Future<void> addTask(
+    String userId,
+    String questId,
+    String text,
+    List<String> assignedPersonIds,
+  ) async {
+    String? sourceTopicId;
+    String? sourcePersonId;
+    if (assignedPersonIds.isNotEmpty) {
+      sourceTopicId =
+          await _catchUpRepo.add(userId, assignedPersonIds.first, text, null);
+      sourcePersonId = assignedPersonIds.first;
+      for (final pid in assignedPersonIds.skip(1)) {
+        await _catchUpRepo.add(userId, pid, text, null);
+      }
+    }
+    final quest = _quests.firstWhere((q) => q.id == questId);
+    final task = FriendsQuestTask(
+      id: _uuid.v4(),
+      text: text,
+      sourceTopicId: sourceTopicId,
+      sourcePersonId: sourcePersonId,
+      assignedPersonIds: assignedPersonIds,
+    );
+    await _repository.updateQuest(
+        userId, quest.copyWith(tasks: [...quest.tasks, task]));
+    _quests = _repository.getAll(userId);
+    notifyListeners();
+  }
+
+  Future<void> editTask(
+    String userId,
+    String questId,
+    String taskId,
+    String newText,
+  ) async {
+    final quest = _quests.firstWhere((q) => q.id == questId);
+    final task = quest.tasks.firstWhere((t) => t.id == taskId);
+
+    if (task.sourceTopicId != null && task.sourcePersonId != null) {
+      try {
+        await _catchUpRepo.update(
+            userId, task.sourcePersonId!, task.sourceTopicId!, newText, null);
+      } catch (_) {}
+
+      // Propagate to couple partner if source person is linked — regardless of quest participants.
+      try {
+        final persons =
+            await _personRepo.getPersonsByIds([task.sourcePersonId!], userId);
+        final partnerId =
+            persons.isNotEmpty ? persons.first.partnerId : null;
+        if (partnerId != null) {
+          final partnerTopics = await _catchUpRepo.getActive(userId, partnerId);
+          final match = partnerTopics.cast<CatchUpTopic?>().firstWhere(
+            (t) =>
+                t!.text.trim().toLowerCase() ==
+                task.text.trim().toLowerCase(),
+            orElse: () => null,
+          );
+          if (match != null) {
+            await _catchUpRepo.update(
+                userId, partnerId, match.id, newText, null);
+          }
+        }
+      } catch (_) {}
+    }
+
+    final updatedTasks = quest.tasks
+        .map((t) => t.id == taskId ? t.copyWith(text: newText) : t)
+        .toList();
+    await _repository.updateQuest(userId, quest.copyWith(tasks: updatedTasks));
+    _quests = _repository.getAll(userId);
+    notifyListeners();
+  }
+
+  Future<void> deleteTask(
+    String userId,
+    String questId,
+    String taskId,
+  ) async {
+    final quest = _quests.firstWhere((q) => q.id == questId);
+    final updatedTasks = quest.tasks.where((t) => t.id != taskId).toList();
+    await _repository.updateQuest(userId, quest.copyWith(tasks: updatedTasks));
+    _quests = _repository.getAll(userId);
+    notifyListeners();
+  }
+
+  Future<void> updateParticipants(
+    String userId,
+    String questId,
+    List<String> newParticipantIds,
+  ) async {
+    final quest = _quests.firstWhere((q) => q.id == questId);
+    final manualTasks =
+        quest.tasks.where((t) => t.sourceTopicId == null).toList();
+    final updated = quest.copyWith(
+      participantIds: newParticipantIds,
+      tasks: manualTasks,
+    );
+    await _repository.updateQuest(userId, updated);
+    _quests = _repository.getAll(userId);
+    await _importTopicsForQuest(userId, questId);
+  }
+
+  Future<void> _importTopicsForQuest(String userId, String questId) async {
+    final quest = _quests.firstWhere((q) => q.id == questId);
+    if (quest.participantIds.isEmpty) return;
+
+    final persons =
+        await _personRepo.getPersonsByIds(quest.participantIds, userId);
+    final personMap = {for (final p in persons) p.id: p};
+
+    // Identify couple pairs both present in this quest.
+    final processedIds = <String>{};
+    final couplePairs = <(String, String)>[];
+    for (final p in persons) {
+      if (processedIds.contains(p.id)) continue;
+      final partnerId = p.partnerId;
+      if (partnerId != null && personMap.containsKey(partnerId)) {
+        couplePairs.add((p.id, partnerId));
+        processedIds.add(p.id);
+        processedIds.add(partnerId);
+      }
+    }
+
+    final allTasks = <FriendsQuestTask>[];
+
+    // Build tasks for couple pairs with deduplication.
+    for (final (aId, bId) in couplePairs) {
+      final aTopics = await _catchUpRepo.getActive(userId, aId);
+      final bTopics = await _catchUpRepo.getActive(userId, bId);
+
+      final bTextMap = {
+        for (final t in bTopics) t.text.trim().toLowerCase(): t,
+      };
+      final aTextMap = {
+        for (final t in aTopics) t.text.trim().toLowerCase(): t,
+      };
+
+      final handledBTexts = <String>{};
+
+      for (final aTopic in aTopics) {
+        final key = aTopic.text.trim().toLowerCase();
+        final bMatch = bTextMap[key];
+        if (bMatch != null) {
+          handledBTexts.add(key);
+          allTasks.add(FriendsQuestTask(
+            id: _uuid.v4(),
+            text: aTopic.text,
+            contextLabel: aTopic.contextLabel,
+            sourceTopicId: aTopic.id,
+            sourcePersonId: aId,
+            assignedPersonIds: [aId, bId],
+          ));
+        } else {
+          allTasks.add(FriendsQuestTask(
+            id: _uuid.v4(),
+            text: aTopic.text,
+            contextLabel: aTopic.contextLabel,
+            sourceTopicId: aTopic.id,
+            sourcePersonId: aId,
+            assignedPersonIds: [aId],
+          ));
+        }
+      }
+
+      // Topics unique to B.
+      for (final bTopic in bTopics) {
+        final key = bTopic.text.trim().toLowerCase();
+        if (!handledBTexts.contains(key) && !aTextMap.containsKey(key)) {
+          allTasks.add(FriendsQuestTask(
+            id: _uuid.v4(),
+            text: bTopic.text,
+            contextLabel: bTopic.contextLabel,
+            sourceTopicId: bTopic.id,
+            sourcePersonId: bId,
+            assignedPersonIds: [bId],
+          ));
+        }
+      }
+    }
+
+    // Build tasks for solo participants.
+    for (final p in persons) {
+      if (processedIds.contains(p.id)) continue;
+      final topics = await _catchUpRepo.getActive(userId, p.id);
+      for (final topic in topics) {
+        allTasks.add(FriendsQuestTask(
+          id: _uuid.v4(),
+          text: topic.text,
+          contextLabel: topic.contextLabel,
+          sourceTopicId: topic.id,
+          sourcePersonId: p.id,
+          assignedPersonIds: [p.id],
+        ));
+      }
+    }
+
+    await _repository.updateQuest(
+        userId, quest.copyWith(tasks: allTasks));
     _quests = _repository.getAll(userId);
     notifyListeners();
   }

--- a/lib/presentation/friends_quest/friends_quest_provider.dart
+++ b/lib/presentation/friends_quest/friends_quest_provider.dart
@@ -117,16 +117,15 @@ class FriendsQuestProvider extends ChangeNotifier {
       try {
         final persons =
             await _personRepo.getPersonsByIds([task.sourcePersonId!], userId);
-        final partnerId =
-            persons.isNotEmpty ? persons.first.partnerId : null;
+        final partnerId = persons.isNotEmpty ? persons.first.partnerId : null;
         if (partnerId != null) {
           final partnerTopics = await _catchUpRepo.getActive(userId, partnerId);
           final match = partnerTopics.cast<CatchUpTopic?>().firstWhere(
-            (t) =>
-                t!.text.trim().toLowerCase() ==
-                task.text.trim().toLowerCase(),
-            orElse: () => null,
-          );
+                (t) =>
+                    t!.text.trim().toLowerCase() ==
+                    task.text.trim().toLowerCase(),
+                orElse: () => null,
+              );
           if (match != null) {
             await _catchUpRepo.update(
                 userId, partnerId, match.id, newText, null);
@@ -266,8 +265,7 @@ class FriendsQuestProvider extends ChangeNotifier {
       }
     }
 
-    await _repository.updateQuest(
-        userId, quest.copyWith(tasks: allTasks));
+    await _repository.updateQuest(userId, quest.copyWith(tasks: allTasks));
     _quests = _repository.getAll(userId);
     notifyListeners();
   }

--- a/lib/presentation/friends_quest/quest_participants_section.dart
+++ b/lib/presentation/friends_quest/quest_participants_section.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/material.dart';
+
+import '../../data/models/person.dart';
+import '../../data/repositories/person_repository.dart';
+
+class QuestParticipantsSection extends StatefulWidget {
+  final List<String> participantIds;
+  final Map<String, Person> personMap;
+  final String userId;
+  final Future<void> Function(List<String> newIds) onParticipantsChanged;
+
+  const QuestParticipantsSection({
+    super.key,
+    required this.participantIds,
+    required this.personMap,
+    required this.userId,
+    required this.onParticipantsChanged,
+  });
+
+  @override
+  State<QuestParticipantsSection> createState() =>
+      _QuestParticipantsSectionState();
+}
+
+class _QuestParticipantsSectionState extends State<QuestParticipantsSection> {
+  bool _updating = false;
+
+  Future<void> _remove(String personId) async {
+    setState(() => _updating = true);
+    final newIds =
+        widget.participantIds.where((id) => id != personId).toList();
+    await widget.onParticipantsChanged(newIds);
+    if (mounted) setState(() => _updating = false);
+  }
+
+  Future<void> _showAddPersonDialog() async {
+    final allPersons = await PersonRepository().getPersonsByUser(widget.userId);
+    final candidates = allPersons
+        .where((p) => !widget.participantIds.contains(p.id))
+        .toList()
+      ..sort((a, b) => a.fullName.compareTo(b.fullName));
+
+    if (!mounted) return;
+
+    var query = '';
+    final added = await showDialog<List<String>>(
+      context: context,
+      builder: (ctx) {
+        final selected = <String>{};
+        return StatefulBuilder(
+          builder: (ctx, setDialog) {
+            final filtered = query.isEmpty
+                ? candidates
+                : candidates
+                    .where((p) =>
+                        p.fullName.toLowerCase().contains(query.toLowerCase()))
+                    .toList();
+            return AlertDialog(
+              title: const Text('Add participants'),
+              content: SizedBox(
+                width: double.maxFinite,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    TextField(
+                      decoration: const InputDecoration(
+                        hintText: 'Search...',
+                        prefixIcon: Icon(Icons.search, size: 20),
+                        isDense: true,
+                        contentPadding: EdgeInsets.symmetric(vertical: 8),
+                      ),
+                      onChanged: (v) => setDialog(() => query = v),
+                    ),
+                    const SizedBox(height: 4),
+                    if (candidates.isEmpty)
+                      const Text('All contacts already added.')
+                    else if (filtered.isEmpty)
+                      const Padding(
+                        padding: EdgeInsets.symmetric(vertical: 8),
+                        child: Text('No matches.',
+                            style: TextStyle(color: Colors.grey)),
+                      )
+                    else
+                      ConstrainedBox(
+                        constraints: const BoxConstraints(maxHeight: 280),
+                        child: ListView.builder(
+                          shrinkWrap: true,
+                          itemCount: filtered.length,
+                          itemBuilder: (_, i) {
+                            final p = filtered[i];
+                            return CheckboxListTile(
+                              dense: true,
+                              title: Text(p.fullName),
+                              value: selected.contains(p.id),
+                              onChanged: (v) => setDialog(() {
+                                if (v == true) {
+                                  selected.add(p.id);
+                                } else {
+                                  selected.remove(p.id);
+                                }
+                              }),
+                            );
+                          },
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.pop(ctx),
+                  child: const Text('CANCEL'),
+                ),
+                TextButton(
+                  onPressed: selected.isEmpty
+                      ? null
+                      : () => Navigator.pop(ctx, selected.toList()),
+                  child: const Text('ADD'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+
+    if (added != null && added.isNotEmpty && mounted) {
+      setState(() => _updating = true);
+      final newIds = [...widget.participantIds, ...added];
+      await widget.onParticipantsChanged(newIds);
+      if (mounted) setState(() => _updating = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+          child: Text(
+            'Participants (${widget.participantIds.length})',
+            style: Theme.of(context).textTheme.titleMedium,
+          ),
+        ),
+        if (widget.participantIds.isEmpty)
+          const Padding(
+            padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Text('No participants.',
+                style: TextStyle(color: Colors.grey)),
+          )
+        else
+          ...widget.participantIds.map((id) {
+            final name = widget.personMap[id]?.fullName ?? id;
+            return ListTile(
+              dense: true,
+              title: Text(name),
+              trailing: _updating
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : IconButton(
+                      icon: const Icon(Icons.remove_circle_outline, size: 20),
+                      onPressed: () => _remove(id),
+                    ),
+            );
+          }),
+        TextButton.icon(
+          onPressed: _updating ? null : _showAddPersonDialog,
+          icon: const Icon(Icons.person_add_outlined),
+          label: const Text('Add participant'),
+        ),
+        const SizedBox(height: 8),
+      ],
+    );
+  }
+}

--- a/lib/presentation/friends_quest/quest_participants_section.dart
+++ b/lib/presentation/friends_quest/quest_participants_section.dart
@@ -27,8 +27,7 @@ class _QuestParticipantsSectionState extends State<QuestParticipantsSection> {
 
   Future<void> _remove(String personId) async {
     setState(() => _updating = true);
-    final newIds =
-        widget.participantIds.where((id) => id != personId).toList();
+    final newIds = widget.participantIds.where((id) => id != personId).toList();
     await widget.onParticipantsChanged(newIds);
     if (mounted) setState(() => _updating = false);
   }
@@ -148,8 +147,8 @@ class _QuestParticipantsSectionState extends State<QuestParticipantsSection> {
         if (widget.participantIds.isEmpty)
           const Padding(
             padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-            child: Text('No participants.',
-                style: TextStyle(color: Colors.grey)),
+            child:
+                Text('No participants.', style: TextStyle(color: Colors.grey)),
           )
         else
           ...widget.participantIds.map((id) {

--- a/lib/presentation/friends_quest/quest_task_tile.dart
+++ b/lib/presentation/friends_quest/quest_task_tile.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+import '../../data/models/friends_quest_task.dart';
+import '../../data/models/person.dart';
+
+class QuestTaskTile extends StatelessWidget {
+  final FriendsQuestTask task;
+  final Map<String, Person> personMap;
+  final VoidCallback onEdit;
+  final VoidCallback onDelete;
+
+  const QuestTaskTile({
+    super.key,
+    required this.task,
+    required this.personMap,
+    required this.onEdit,
+    required this.onDelete,
+  });
+
+  String _subtitle() {
+    final names = task.assignedPersonIds.isEmpty
+        ? ''
+        : task.assignedPersonIds
+            .map((id) => personMap[id]?.fullName ?? id)
+            .join(', ');
+    final label = task.contextLabel ?? '';
+    if (names.isNotEmpty && label.isNotEmpty) return '$names · $label';
+    if (names.isNotEmpty) return names;
+    if (label.isNotEmpty) return label;
+    return '';
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final sub = _subtitle();
+    return ListTile(
+      leading: Checkbox(
+        value: task.isCompleted,
+        onChanged: null,
+      ),
+      title: Text(
+        task.text,
+        style: task.isCompleted
+            ? const TextStyle(decoration: TextDecoration.lineThrough)
+            : null,
+      ),
+      subtitle: sub.isNotEmpty ? Text(sub) : null,
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            icon: const Icon(Icons.edit_outlined, size: 20),
+            onPressed: onEdit,
+          ),
+          IconButton(
+            icon: const Icon(Icons.delete_outline, size: 20),
+            onPressed: onDelete,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/data/repositories/friends_quest_repository_test.dart
+++ b/test/data/repositories/friends_quest_repository_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:friendsheet/data/models/friends_quest_task.dart';
 import 'package:friendsheet/data/repositories/friends_quest_repository.dart';
 import 'package:friendsheet/services/hive_service.dart';
 import 'package:hive/hive.dart';
@@ -86,6 +87,42 @@ void main() {
       final loaded = repository.getAll(userId);
       expect(loaded.first.participantIds, ['p1', 'p2']);
       expect(loaded.first.isCompleted, false);
+    });
+
+    test('updateQuest replaces matching quest, others unchanged', () async {
+      final q1 = await repository.create(userId, 'Quest A', []);
+      await repository.create(userId, 'Quest B', []);
+
+      final task = FriendsQuestTask(id: 't1', text: 'Do something');
+      await repository.updateQuest(userId, q1.copyWith(tasks: [task]));
+
+      final all = repository.getAll(userId);
+      expect(all, hasLength(2));
+      final found = all.firstWhere((q) => q.id == q1.id);
+      expect(found.tasks, hasLength(1));
+      expect(found.tasks.first.text, 'Do something');
+      expect(all.firstWhere((q) => q.name == 'Quest B').tasks, isEmpty);
+    });
+
+    test('updateQuest persists nested tasks (round-trip serialization)',
+        () async {
+      final q = await repository.create(userId, 'Quest', []);
+      final task = FriendsQuestTask(
+        id: 't1',
+        text: 'Nested task',
+        contextLabel: 'ctx',
+        sourceTopicId: 'src-1',
+        sourcePersonId: 'p1',
+        assignedPersonIds: const ['p1', 'p2'],
+      );
+      await repository.updateQuest(userId, q.copyWith(tasks: [task]));
+
+      final loaded = repository.getAll(userId).first;
+      expect(loaded.tasks, hasLength(1));
+      expect(loaded.tasks.first.text, 'Nested task');
+      expect(loaded.tasks.first.contextLabel, 'ctx');
+      expect(loaded.tasks.first.sourceTopicId, 'src-1');
+      expect(loaded.tasks.first.assignedPersonIds, ['p1', 'p2']);
     });
   });
 }

--- a/test/data/repositories/friends_quest_repository_test.dart
+++ b/test/data/repositories/friends_quest_repository_test.dart
@@ -93,7 +93,7 @@ void main() {
       final q1 = await repository.create(userId, 'Quest A', []);
       await repository.create(userId, 'Quest B', []);
 
-      final task = FriendsQuestTask(id: 't1', text: 'Do something');
+      const task = FriendsQuestTask(id: 't1', text: 'Do something');
       await repository.updateQuest(userId, q1.copyWith(tasks: [task]));
 
       final all = repository.getAll(userId);
@@ -107,13 +107,13 @@ void main() {
     test('updateQuest persists nested tasks (round-trip serialization)',
         () async {
       final q = await repository.create(userId, 'Quest', []);
-      final task = FriendsQuestTask(
+      const task = FriendsQuestTask(
         id: 't1',
         text: 'Nested task',
         contextLabel: 'ctx',
         sourceTopicId: 'src-1',
         sourcePersonId: 'p1',
-        assignedPersonIds: const ['p1', 'p2'],
+        assignedPersonIds: ['p1', 'p2'],
       );
       await repository.updateQuest(userId, q.copyWith(tasks: [task]));
 

--- a/test/presentation/friends_quest/friends_quest_provider_test.dart
+++ b/test/presentation/friends_quest/friends_quest_provider_test.dart
@@ -1,5 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:friendsheet/data/models/catch_up_topic.dart';
 import 'package:friendsheet/data/models/friends_quest.dart';
+import 'package:friendsheet/data/models/friends_quest_task.dart';
+import 'package:friendsheet/data/models/person.dart';
 import 'package:friendsheet/data/repositories/catch_up_topic_repository.dart';
 import 'package:friendsheet/data/repositories/friends_quest_repository.dart';
 import 'package:friendsheet/data/repositories/person_repository.dart';
@@ -9,7 +12,8 @@ import 'package:mockito/mockito.dart';
 
 import 'friends_quest_provider_test.mocks.dart';
 
-@GenerateMocks([FriendsQuestRepository, CatchUpTopicRepository, PersonRepository])
+@GenerateMocks(
+    [FriendsQuestRepository, CatchUpTopicRepository, PersonRepository])
 void main() {
   late MockFriendsQuestRepository mockRepo;
   late MockCatchUpTopicRepository mockCatchUpRepo;
@@ -107,6 +111,152 @@ void main() {
       provider.loadQuests('u1');
 
       expect(notified, true);
+    });
+
+    test('addTask without assignees adds task and skips catchup', () async {
+      when(mockRepo.getAll('u1')).thenReturn([activeQuest]);
+      provider.loadQuests('u1');
+
+      await provider.addTask('u1', 'q1', 'Buy milk', []);
+
+      final captured = verify(mockRepo.updateQuest('u1', captureAny)).captured;
+      final saved = captured.last as FriendsQuest;
+      expect(saved.tasks, hasLength(1));
+      expect(saved.tasks.first.text, 'Buy milk');
+      expect(saved.tasks.first.assignedPersonIds, isEmpty);
+      expect(saved.tasks.first.sourceTopicId, isNull);
+      verifyNever(mockCatchUpRepo.add(any, any, any, any));
+    });
+
+    test('addTask with assignees calls catchup.add and sets source fields',
+        () async {
+      when(mockRepo.getAll('u1')).thenReturn([activeQuest]);
+      provider.loadQuests('u1');
+      when(mockCatchUpRepo.add('u1', 'p1', 'Buy milk', null))
+          .thenAnswer((_) async => 'topic-1');
+      when(mockCatchUpRepo.add('u1', 'p2', 'Buy milk', null))
+          .thenAnswer((_) async => 'topic-2');
+
+      await provider.addTask('u1', 'q1', 'Buy milk', ['p1', 'p2']);
+
+      verify(mockCatchUpRepo.add('u1', 'p1', 'Buy milk', null)).called(1);
+      verify(mockCatchUpRepo.add('u1', 'p2', 'Buy milk', null)).called(1);
+      final captured = verify(mockRepo.updateQuest('u1', captureAny)).captured;
+      final saved = captured.last as FriendsQuest;
+      expect(saved.tasks.first.sourceTopicId, 'topic-1');
+      expect(saved.tasks.first.sourcePersonId, 'p1');
+      expect(saved.tasks.first.assignedPersonIds, ['p1', 'p2']);
+    });
+
+    test('deleteTask removes task from quest', () async {
+      final questWithTask = activeQuest.copyWith(tasks: [
+        const FriendsQuestTask(id: 't1', text: 'Do something'),
+      ]);
+      when(mockRepo.getAll('u1')).thenReturn([questWithTask]);
+      provider.loadQuests('u1');
+
+      await provider.deleteTask('u1', 'q1', 't1');
+
+      final captured = verify(mockRepo.updateQuest('u1', captureAny)).captured;
+      final saved = captured.last as FriendsQuest;
+      expect(saved.tasks, isEmpty);
+    });
+
+    test('editTask without sourceTopicId updates text only, no catchup call',
+        () async {
+      final questWithTask = activeQuest.copyWith(tasks: [
+        const FriendsQuestTask(id: 't1', text: 'Old text'),
+      ]);
+      when(mockRepo.getAll('u1')).thenReturn([questWithTask]);
+      provider.loadQuests('u1');
+
+      await provider.editTask('u1', 'q1', 't1', 'New text');
+
+      verifyNever(mockCatchUpRepo.update(any, any, any, any, any));
+      final captured = verify(mockRepo.updateQuest('u1', captureAny)).captured;
+      final saved = captured.last as FriendsQuest;
+      expect(saved.tasks.first.text, 'New text');
+    });
+
+    test('editTask with sourceTopicId calls catchup.update', () async {
+      final questWithTask = activeQuest.copyWith(tasks: [
+        const FriendsQuestTask(
+          id: 't1',
+          text: 'Old text',
+          sourceTopicId: 'src-1',
+          sourcePersonId: 'p1',
+        ),
+      ]);
+      when(mockRepo.getAll('u1')).thenReturn([questWithTask]);
+      provider.loadQuests('u1');
+      when(mockPersonRepo.getPersonsByIds(['p1'], 'u1'))
+          .thenAnswer((_) async => []);
+
+      await provider.editTask('u1', 'q1', 't1', 'New text');
+
+      verify(mockCatchUpRepo.update('u1', 'p1', 'src-1', 'New text', null))
+          .called(1);
+    });
+
+    test('updateParticipants keeps manual tasks and drops imported tasks',
+        () async {
+      final questWithTasks = activeQuest.copyWith(tasks: [
+        const FriendsQuestTask(id: 't1', text: 'Manual'),
+        const FriendsQuestTask(
+            id: 't2', text: 'Imported', sourceTopicId: 'src-1'),
+      ]);
+      when(mockRepo.getAll('u1')).thenReturn([questWithTasks]);
+      provider.loadQuests('u1');
+      when(mockPersonRepo.getPersonsByIds(any, any))
+          .thenAnswer((_) async => []);
+
+      await provider.updateParticipants('u1', 'q1', ['p3']);
+
+      final allCaptured =
+          verify(mockRepo.updateQuest('u1', captureAny)).captured;
+      final firstSaved = allCaptured.first as FriendsQuest;
+      expect(firstSaved.tasks, hasLength(1));
+      expect(firstSaved.tasks.first.id, 't1');
+      expect(firstSaved.participantIds, ['p3']);
+    });
+
+    test('createQuest with participants imports topics as tasks', () async {
+      final createdQuest = FriendsQuest(
+        id: 'q3',
+        name: 'Import test',
+        participantIds: ['p1'],
+        createdAt: DateTime(2026),
+      );
+      when(mockRepo.create('u1', 'Import test', ['p1']))
+          .thenAnswer((_) async => createdQuest);
+      when(mockRepo.getAll('u1')).thenReturn([createdQuest]);
+
+      final person = Person(
+        id: 'p1',
+        userId: 'u1',
+        firstName: 'Alice',
+        createdAt: DateTime(2026),
+      );
+      when(mockPersonRepo.getPersonsByIds(['p1'], 'u1'))
+          .thenAnswer((_) async => [person]);
+      final topic = CatchUpTopic(
+        id: 'topic-1',
+        text: 'Catch up',
+        createdAt: DateTime(2026),
+      );
+      when(mockCatchUpRepo.getActive('u1', 'p1'))
+          .thenAnswer((_) async => [topic]);
+
+      await provider.createQuest('u1', 'Import test', ['p1']);
+
+      final allCaptured =
+          verify(mockRepo.updateQuest('u1', captureAny)).captured;
+      final savedQuest = allCaptured.last as FriendsQuest;
+      expect(savedQuest.tasks, hasLength(1));
+      expect(savedQuest.tasks.first.text, 'Catch up');
+      expect(savedQuest.tasks.first.sourceTopicId, 'topic-1');
+      expect(savedQuest.tasks.first.assignedPersonIds, ['p1']);
+      expect(provider.isLoading, false);
     });
   });
 }

--- a/test/presentation/friends_quest/friends_quest_provider_test.dart
+++ b/test/presentation/friends_quest/friends_quest_provider_test.dart
@@ -1,15 +1,19 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:friendsheet/data/models/friends_quest.dart';
+import 'package:friendsheet/data/repositories/catch_up_topic_repository.dart';
 import 'package:friendsheet/data/repositories/friends_quest_repository.dart';
+import 'package:friendsheet/data/repositories/person_repository.dart';
 import 'package:friendsheet/presentation/friends_quest/friends_quest_provider.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 
 import 'friends_quest_provider_test.mocks.dart';
 
-@GenerateMocks([FriendsQuestRepository])
+@GenerateMocks([FriendsQuestRepository, CatchUpTopicRepository, PersonRepository])
 void main() {
   late MockFriendsQuestRepository mockRepo;
+  late MockCatchUpTopicRepository mockCatchUpRepo;
+  late MockPersonRepository mockPersonRepo;
   late FriendsQuestProvider provider;
 
   final activeQuest = FriendsQuest(
@@ -28,7 +32,13 @@ void main() {
 
   setUp(() {
     mockRepo = MockFriendsQuestRepository();
-    provider = FriendsQuestProvider(repository: mockRepo);
+    mockCatchUpRepo = MockCatchUpTopicRepository();
+    mockPersonRepo = MockPersonRepository();
+    provider = FriendsQuestProvider(
+      repository: mockRepo,
+      catchUpRepo: mockCatchUpRepo,
+      personRepo: mockPersonRepo,
+    );
   });
 
   tearDown(() => provider.dispose());
@@ -57,14 +67,21 @@ void main() {
       expect(provider.activeQuests.first.id, 'q1');
     });
 
-    test('createQuest calls repo and refreshes list', () async {
-      when(mockRepo.create('u1', 'New quest', ['p1']))
-          .thenAnswer((_) async => activeQuest);
-      when(mockRepo.getAll('u1')).thenReturn([activeQuest]);
+    test('createQuest with no participants skips import', () async {
+      final noParticipantQuest = FriendsQuest(
+        id: 'q3',
+        name: 'Solo',
+        participantIds: [],
+        createdAt: DateTime(2026),
+      );
+      when(mockRepo.create('u1', 'Solo', []))
+          .thenAnswer((_) async => noParticipantQuest);
+      when(mockRepo.getAll('u1')).thenReturn([noParticipantQuest]);
 
-      await provider.createQuest('u1', 'New quest', ['p1']);
+      await provider.createQuest('u1', 'Solo', []);
 
-      verify(mockRepo.create('u1', 'New quest', ['p1'])).called(1);
+      verify(mockRepo.create('u1', 'Solo', [])).called(1);
+      verifyNever(mockPersonRepo.getPersonsByIds(any, any));
       expect(provider.quests, hasLength(1));
       expect(provider.isLoading, false);
     });

--- a/test/presentation/friends_quest/friends_quest_provider_test.mocks.dart
+++ b/test/presentation/friends_quest/friends_quest_provider_test.mocks.dart
@@ -3,12 +3,19 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i4;
+import 'dart:async' as _i5;
 
+import 'package:friendsheet/data/models/catch_up_topic.dart' as _i8;
 import 'package:friendsheet/data/models/friends_quest.dart' as _i2;
+import 'package:friendsheet/data/models/person.dart' as _i3;
+import 'package:friendsheet/data/repositories/cache_invalidator.dart' as _i10;
+import 'package:friendsheet/data/repositories/catch_up_topic_repository.dart'
+    as _i6;
 import 'package:friendsheet/data/repositories/friends_quest_repository.dart'
-    as _i3;
+    as _i4;
+import 'package:friendsheet/data/repositories/person_repository.dart' as _i9;
 import 'package:mockito/mockito.dart' as _i1;
+import 'package:mockito/src/dummies.dart' as _i7;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -34,11 +41,21 @@ class _FakeFriendsQuest_0 extends _i1.SmartFake implements _i2.FriendsQuest {
         );
 }
 
+class _FakePerson_1 extends _i1.SmartFake implements _i3.Person {
+  _FakePerson_1(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [FriendsQuestRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockFriendsQuestRepository extends _i1.Mock
-    implements _i3.FriendsQuestRepository {
+    implements _i4.FriendsQuestRepository {
   MockFriendsQuestRepository() {
     _i1.throwOnMissingStub(this);
   }
@@ -53,7 +70,7 @@ class MockFriendsQuestRepository extends _i1.Mock
       ) as List<_i2.FriendsQuest>);
 
   @override
-  _i4.Future<_i2.FriendsQuest> create(
+  _i5.Future<_i2.FriendsQuest> create(
     String? userId,
     String? name,
     List<String>? participantIds,
@@ -67,7 +84,7 @@ class MockFriendsQuestRepository extends _i1.Mock
             participantIds,
           ],
         ),
-        returnValue: _i4.Future<_i2.FriendsQuest>.value(_FakeFriendsQuest_0(
+        returnValue: _i5.Future<_i2.FriendsQuest>.value(_FakeFriendsQuest_0(
           this,
           Invocation.method(
             #create,
@@ -78,10 +95,10 @@ class MockFriendsQuestRepository extends _i1.Mock
             ],
           ),
         )),
-      ) as _i4.Future<_i2.FriendsQuest>);
+      ) as _i5.Future<_i2.FriendsQuest>);
 
   @override
-  _i4.Future<void> delete(
+  _i5.Future<void> delete(
     String? userId,
     String? questId,
   ) =>
@@ -93,7 +110,347 @@ class MockFriendsQuestRepository extends _i1.Mock
             questId,
           ],
         ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> updateQuest(
+    String? userId,
+    _i2.FriendsQuest? quest,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #updateQuest,
+          [
+            userId,
+            quest,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+}
+
+/// A class which mocks [CatchUpTopicRepository].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockCatchUpTopicRepository extends _i1.Mock
+    implements _i6.CatchUpTopicRepository {
+  MockCatchUpTopicRepository() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i5.Future<String> add(
+    String? userId,
+    String? personId,
+    String? text,
+    String? contextLabel,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #add,
+          [
+            userId,
+            personId,
+            text,
+            contextLabel,
+          ],
+        ),
+        returnValue: _i5.Future<String>.value(_i7.dummyValue<String>(
+          this,
+          Invocation.method(
+            #add,
+            [
+              userId,
+              personId,
+              text,
+              contextLabel,
+            ],
+          ),
+        )),
+      ) as _i5.Future<String>);
+
+  @override
+  _i5.Future<List<_i8.CatchUpTopic>> getActive(
+    String? userId,
+    String? personId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getActive,
+          [
+            userId,
+            personId,
+          ],
+        ),
+        returnValue:
+            _i5.Future<List<_i8.CatchUpTopic>>.value(<_i8.CatchUpTopic>[]),
+      ) as _i5.Future<List<_i8.CatchUpTopic>>);
+
+  @override
+  _i5.Future<void> update(
+    String? userId,
+    String? personId,
+    String? topicId,
+    String? text,
+    String? contextLabel,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #update,
+          [
+            userId,
+            personId,
+            topicId,
+            text,
+            contextLabel,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> archive(
+    String? userId,
+    String? personId,
+    String? topicId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #archive,
+          [
+            userId,
+            personId,
+            topicId,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<List<_i8.CatchUpTopic>> getArchived(
+    String? userId,
+    String? personId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getArchived,
+          [
+            userId,
+            personId,
+          ],
+        ),
+        returnValue:
+            _i5.Future<List<_i8.CatchUpTopic>>.value(<_i8.CatchUpTopic>[]),
+      ) as _i5.Future<List<_i8.CatchUpTopic>>);
+
+  @override
+  _i5.Future<void> mergeTopics(
+    String? userId,
+    String? personId,
+    String? partnerId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #mergeTopics,
+          [
+            userId,
+            personId,
+            partnerId,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> delete(
+    String? userId,
+    String? personId,
+    String? topicId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #delete,
+          [
+            userId,
+            personId,
+            topicId,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> applyRedistribution(
+    String? userId,
+    String? personId,
+    String? partnerId,
+    List<_i8.CatchUpTopic>? postLinkTopics,
+    Map<String, _i6.TopicRedistributionDecision>? decisions,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #applyRedistribution,
+          [
+            userId,
+            personId,
+            partnerId,
+            postLinkTopics,
+            decisions,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+}
+
+/// A class which mocks [PersonRepository].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockPersonRepository extends _i1.Mock implements _i9.PersonRepository {
+  MockPersonRepository() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  set cacheInvalidator(_i10.CacheInvalidator? _cacheInvalidator) =>
+      super.noSuchMethod(
+        Invocation.setter(
+          #cacheInvalidator,
+          _cacheInvalidator,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<List<_i3.Person>> getPersonsByUser(String? userId) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getPersonsByUser,
+          [userId],
+        ),
+        returnValue: _i5.Future<List<_i3.Person>>.value(<_i3.Person>[]),
+      ) as _i5.Future<List<_i3.Person>>);
+
+  @override
+  _i5.Future<List<_i3.Person>> getPersonsByIds(
+    List<String>? ids,
+    String? userId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getPersonsByIds,
+          [
+            ids,
+            userId,
+          ],
+        ),
+        returnValue: _i5.Future<List<_i3.Person>>.value(<_i3.Person>[]),
+      ) as _i5.Future<List<_i3.Person>>);
+
+  @override
+  _i5.Future<_i3.Person> addPerson(_i3.Person? person) => (super.noSuchMethod(
+        Invocation.method(
+          #addPerson,
+          [person],
+        ),
+        returnValue: _i5.Future<_i3.Person>.value(_FakePerson_1(
+          this,
+          Invocation.method(
+            #addPerson,
+            [person],
+          ),
+        )),
+      ) as _i5.Future<_i3.Person>);
+
+  @override
+  _i5.Future<void> updatePerson(_i3.Person? person) => (super.noSuchMethod(
+        Invocation.method(
+          #updatePerson,
+          [person],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<bool> isDuplicateName(
+    String? userId,
+    String? firstName,
+    String? lastName, {
+    String? excludeId,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #isDuplicateName,
+          [
+            userId,
+            firstName,
+            lastName,
+          ],
+          {#excludeId: excludeId},
+        ),
+        returnValue: _i5.Future<bool>.value(false),
+      ) as _i5.Future<bool>);
+
+  @override
+  _i5.Future<void> linkPartner(
+    String? userId,
+    String? personId,
+    String? partnerId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #linkPartner,
+          [
+            userId,
+            personId,
+            partnerId,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> unlinkPartner(
+    String? userId,
+    String? personId,
+    String? partnerId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #unlinkPartner,
+          [
+            userId,
+            personId,
+            partnerId,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> deletePerson(
+    String? userId,
+    String? personId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deletePerson,
+          [
+            userId,
+            personId,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
 }

--- a/test/presentation/friends_quest/quest_task_tile_test.dart
+++ b/test/presentation/friends_quest/quest_task_tile_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:friendsheet/data/models/friends_quest_task.dart';
+import 'package:friendsheet/data/models/person.dart';
+import 'package:friendsheet/presentation/friends_quest/quest_task_tile.dart';
+
+void main() {
+  Person makePerson(String id, String name) => Person(
+        id: id,
+        userId: 'u1',
+        firstName: name,
+        createdAt: DateTime(2026),
+      );
+
+  Widget wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+
+  group('QuestTaskTile', () {
+    testWidgets('shows task text and read-only checkbox', (tester) async {
+      await tester.pumpWidget(wrap(QuestTaskTile(
+        task: const FriendsQuestTask(id: 't1', text: 'Buy milk'),
+        personMap: const {},
+        onEdit: () {},
+        onDelete: () {},
+      )));
+
+      expect(find.text('Buy milk'), findsOneWidget);
+      final cb = tester.widget<Checkbox>(find.byType(Checkbox));
+      expect(cb.onChanged, isNull);
+    });
+
+    testWidgets('shows assigned person names in subtitle', (tester) async {
+      await tester.pumpWidget(wrap(QuestTaskTile(
+        task: const FriendsQuestTask(
+          id: 't1',
+          text: 'Task',
+          assignedPersonIds: ['p1', 'p2'],
+        ),
+        personMap: {
+          'p1': makePerson('p1', 'Alice'),
+          'p2': makePerson('p2', 'Bob')
+        },
+        onEdit: () {},
+        onDelete: () {},
+      )));
+
+      expect(find.text('Alice, Bob'), findsOneWidget);
+    });
+
+    testWidgets('shows names and contextLabel combined in subtitle',
+        (tester) async {
+      await tester.pumpWidget(wrap(QuestTaskTile(
+        task: const FriendsQuestTask(
+          id: 't1',
+          text: 'Task',
+          assignedPersonIds: ['p1'],
+          contextLabel: 'Dinner',
+        ),
+        personMap: {'p1': makePerson('p1', 'Alice')},
+        onEdit: () {},
+        onDelete: () {},
+      )));
+
+      expect(find.text('Alice · Dinner'), findsOneWidget);
+    });
+
+    testWidgets('edit and delete buttons trigger callbacks', (tester) async {
+      var edited = false;
+      var deleted = false;
+      await tester.pumpWidget(wrap(QuestTaskTile(
+        task: const FriendsQuestTask(id: 't1', text: 'Task'),
+        personMap: const {},
+        onEdit: () => edited = true,
+        onDelete: () => deleted = true,
+      )));
+
+      await tester.tap(find.byIcon(Icons.edit_outlined));
+      await tester.tap(find.byIcon(Icons.delete_outline));
+
+      expect(edited, true);
+      expect(deleted, true);
+    });
+
+    testWidgets('completed task shows strikethrough text', (tester) async {
+      await tester.pumpWidget(wrap(QuestTaskTile(
+        task: const FriendsQuestTask(id: 't1', text: 'Done', isCompleted: true),
+        personMap: const {},
+        onEdit: () {},
+        onDelete: () {},
+      )));
+
+      final textWidget = tester.widget<Text>(find.text('Done'));
+      expect(textWidget.style?.decoration, TextDecoration.lineThrough);
+    });
+  });
+}

--- a/test/presentation/screens/home_screen_test.dart
+++ b/test/presentation/screens/home_screen_test.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:friendsheet/data/models/meeting.dart';
 import 'package:friendsheet/data/repositories/activity_category_repository.dart';
+import 'package:friendsheet/data/repositories/catch_up_topic_repository.dart';
+import 'package:friendsheet/data/repositories/friends_quest_repository.dart';
 import 'package:friendsheet/data/repositories/meeting_repository.dart';
 import 'package:friendsheet/data/repositories/person_repository.dart';
 import 'package:friendsheet/data/repositories/statistics_repository.dart';
@@ -82,6 +84,8 @@ const Widget _stubImage = SizedBox(key: Key('stub_image'), height: 120);
   PersonRepository,
   MeetingRepository,
   LtnsExclusionService,
+  FriendsQuestRepository,
+  CatchUpTopicRepository,
 ])
 void main() {
   late MockStatisticsRepository mockRepository;
@@ -90,6 +94,8 @@ void main() {
   late MockPersonRepository mockPersonRepository;
   late MockMeetingRepository mockMeetingRepository;
   late MockLtnsExclusionService mockLtnsExclusionService;
+  late MockFriendsQuestRepository mockFriendsQuestRepository;
+  late MockCatchUpTopicRepository mockCatchUpTopicRepository;
   late StatisticsProvider statisticsProvider;
   late HomeProvider homeProvider;
   late BuddyWidgetProvider buddyWidgetProvider;
@@ -118,7 +124,14 @@ void main() {
     // Default stub: no LTNS exclusions (US-118).
     when(mockLtnsExclusionService.getExcludedIds())
         .thenAnswer((_) async => <String>{});
-    friendsQuestProvider = FriendsQuestProvider();
+    mockFriendsQuestRepository = MockFriendsQuestRepository();
+    mockCatchUpTopicRepository = MockCatchUpTopicRepository();
+    when(mockFriendsQuestRepository.getAll(any)).thenReturn([]);
+    friendsQuestProvider = FriendsQuestProvider(
+      repository: mockFriendsQuestRepository,
+      catchUpRepo: mockCatchUpTopicRepository,
+      personRepo: mockPersonRepository,
+    );
     homeProvider = HomeProvider(meetingRepository: mockMeetingRepository);
     buddyWidgetProvider = BuddyWidgetProvider(
       meetingRepository: mockMeetingRepository,

--- a/test/presentation/screens/home_screen_test.mocks.dart
+++ b/test/presentation/screens/home_screen_test.mocks.dart
@@ -3,24 +3,30 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i6;
+import 'dart:async' as _i7;
 
-import 'package:firebase_auth/firebase_auth.dart' as _i9;
+import 'package:firebase_auth/firebase_auth.dart' as _i10;
 import 'package:friendsheet/data/models/activity_category.dart' as _i3;
-import 'package:friendsheet/data/models/meeting.dart' as _i7;
+import 'package:friendsheet/data/models/catch_up_topic.dart' as _i19;
+import 'package:friendsheet/data/models/friends_quest.dart' as _i5;
+import 'package:friendsheet/data/models/meeting.dart' as _i8;
 import 'package:friendsheet/data/models/person.dart' as _i4;
 import 'package:friendsheet/data/models/stats_data_bundle.dart' as _i2;
 import 'package:friendsheet/data/repositories/activity_category_repository.dart'
-    as _i10;
-import 'package:friendsheet/data/repositories/cache_invalidator.dart' as _i11;
-import 'package:friendsheet/data/repositories/meeting_repository.dart' as _i13;
-import 'package:friendsheet/data/repositories/person_repository.dart' as _i12;
+    as _i11;
+import 'package:friendsheet/data/repositories/cache_invalidator.dart' as _i12;
+import 'package:friendsheet/data/repositories/catch_up_topic_repository.dart'
+    as _i18;
+import 'package:friendsheet/data/repositories/friends_quest_repository.dart'
+    as _i17;
+import 'package:friendsheet/data/repositories/meeting_repository.dart' as _i14;
+import 'package:friendsheet/data/repositories/person_repository.dart' as _i13;
 import 'package:friendsheet/data/repositories/statistics_repository.dart'
-    as _i5;
-import 'package:friendsheet/data/services/auth_service.dart' as _i8;
-import 'package:friendsheet/data/services/ltns_exclusion_service.dart' as _i15;
+    as _i6;
+import 'package:friendsheet/data/services/auth_service.dart' as _i9;
+import 'package:friendsheet/data/services/ltns_exclusion_service.dart' as _i16;
 import 'package:mockito/mockito.dart' as _i1;
-import 'package:mockito/src/dummies.dart' as _i14;
+import 'package:mockito/src/dummies.dart' as _i15;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -68,67 +74,77 @@ class _FakePerson_2 extends _i1.SmartFake implements _i4.Person {
         );
 }
 
+class _FakeFriendsQuest_3 extends _i1.SmartFake implements _i5.FriendsQuest {
+  _FakeFriendsQuest_3(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [StatisticsRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockStatisticsRepository extends _i1.Mock
-    implements _i5.StatisticsRepository {
+    implements _i6.StatisticsRepository {
   MockStatisticsRepository() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i6.Future<void> invalidateMeetingsCache() => (super.noSuchMethod(
+  _i7.Future<void> invalidateMeetingsCache() => (super.noSuchMethod(
         Invocation.method(
           #invalidateMeetingsCache,
           [],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<void> invalidateCategoriesCache() => (super.noSuchMethod(
+  _i7.Future<void> invalidateCategoriesCache() => (super.noSuchMethod(
         Invocation.method(
           #invalidateCategoriesCache,
           [],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<void> invalidatePersonsCache() => (super.noSuchMethod(
+  _i7.Future<void> invalidatePersonsCache() => (super.noSuchMethod(
         Invocation.method(
           #invalidatePersonsCache,
           [],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<void> invalidateAllCaches() => (super.noSuchMethod(
+  _i7.Future<void> invalidateAllCaches() => (super.noSuchMethod(
         Invocation.method(
           #invalidateAllCaches,
           [],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<List<int>> getAvailableYears(String? userId) =>
+  _i7.Future<List<int>> getAvailableYears(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getAvailableYears,
           [userId],
         ),
-        returnValue: _i6.Future<List<int>>.value(<int>[]),
-      ) as _i6.Future<List<int>>);
+        returnValue: _i7.Future<List<int>>.value(<int>[]),
+      ) as _i7.Future<List<int>>);
 
   @override
-  _i6.Future<List<_i7.Meeting>> getMeetingsForYear(
+  _i7.Future<List<_i8.Meeting>> getMeetingsForYear(
     String? userId,
     int? year,
   ) =>
@@ -140,11 +156,11 @@ class MockStatisticsRepository extends _i1.Mock
             year,
           ],
         ),
-        returnValue: _i6.Future<List<_i7.Meeting>>.value(<_i7.Meeting>[]),
-      ) as _i6.Future<List<_i7.Meeting>>);
+        returnValue: _i7.Future<List<_i8.Meeting>>.value(<_i8.Meeting>[]),
+      ) as _i7.Future<List<_i8.Meeting>>);
 
   @override
-  _i6.Future<_i2.StatsDataBundle> loadAllStatsData(
+  _i7.Future<_i2.StatsDataBundle> loadAllStatsData(
     int? year,
     String? userId,
   ) =>
@@ -157,7 +173,7 @@ class MockStatisticsRepository extends _i1.Mock
           ],
         ),
         returnValue:
-            _i6.Future<_i2.StatsDataBundle>.value(_FakeStatsDataBundle_0(
+            _i7.Future<_i2.StatsDataBundle>.value(_FakeStatsDataBundle_0(
           this,
           Invocation.method(
             #loadAllStatsData,
@@ -167,21 +183,21 @@ class MockStatisticsRepository extends _i1.Mock
             ],
           ),
         )),
-      ) as _i6.Future<_i2.StatsDataBundle>);
+      ) as _i7.Future<_i2.StatsDataBundle>);
 
   @override
-  List<_i5.ActivityBreakdownEntry> computeActivityBreakdown(
+  List<_i6.ActivityBreakdownEntry> computeActivityBreakdown(
           _i2.StatsDataBundle? bundle) =>
       (super.noSuchMethod(
         Invocation.method(
           #computeActivityBreakdown,
           [bundle],
         ),
-        returnValue: <_i5.ActivityBreakdownEntry>[],
-      ) as List<_i5.ActivityBreakdownEntry>);
+        returnValue: <_i6.ActivityBreakdownEntry>[],
+      ) as List<_i6.ActivityBreakdownEntry>);
 
   @override
-  List<_i5.PersonActivityEntry> computePersonsForActivity(
+  List<_i6.PersonActivityEntry> computePersonsForActivity(
     _i2.StatsDataBundle? bundle,
     String? categoryId,
   ) =>
@@ -193,22 +209,22 @@ class MockStatisticsRepository extends _i1.Mock
             categoryId,
           ],
         ),
-        returnValue: <_i5.PersonActivityEntry>[],
-      ) as List<_i5.PersonActivityEntry>);
+        returnValue: <_i6.PersonActivityEntry>[],
+      ) as List<_i6.PersonActivityEntry>);
 
   @override
-  List<_i5.InteractionDistributionEntry> computeInteractionDistribution(
+  List<_i6.InteractionDistributionEntry> computeInteractionDistribution(
           _i2.StatsDataBundle? bundle) =>
       (super.noSuchMethod(
         Invocation.method(
           #computeInteractionDistribution,
           [bundle],
         ),
-        returnValue: <_i5.InteractionDistributionEntry>[],
-      ) as List<_i5.InteractionDistributionEntry>);
+        returnValue: <_i6.InteractionDistributionEntry>[],
+      ) as List<_i6.InteractionDistributionEntry>);
 
   @override
-  _i6.Future<List<_i5.ActivityBreakdownEntry>> getActivityWeightBreakdown(
+  _i7.Future<List<_i6.ActivityBreakdownEntry>> getActivityWeightBreakdown(
     int? year,
     String? userId,
   ) =>
@@ -220,12 +236,12 @@ class MockStatisticsRepository extends _i1.Mock
             userId,
           ],
         ),
-        returnValue: _i6.Future<List<_i5.ActivityBreakdownEntry>>.value(
-            <_i5.ActivityBreakdownEntry>[]),
-      ) as _i6.Future<List<_i5.ActivityBreakdownEntry>>);
+        returnValue: _i7.Future<List<_i6.ActivityBreakdownEntry>>.value(
+            <_i6.ActivityBreakdownEntry>[]),
+      ) as _i7.Future<List<_i6.ActivityBreakdownEntry>>);
 
   @override
-  _i6.Future<List<_i5.PersonActivityEntry>> getPersonsForActivity(
+  _i7.Future<List<_i6.PersonActivityEntry>> getPersonsForActivity(
     String? categoryId,
     int? year,
     String? userId,
@@ -239,12 +255,12 @@ class MockStatisticsRepository extends _i1.Mock
             userId,
           ],
         ),
-        returnValue: _i6.Future<List<_i5.PersonActivityEntry>>.value(
-            <_i5.PersonActivityEntry>[]),
-      ) as _i6.Future<List<_i5.PersonActivityEntry>>);
+        returnValue: _i7.Future<List<_i6.PersonActivityEntry>>.value(
+            <_i6.PersonActivityEntry>[]),
+      ) as _i7.Future<List<_i6.PersonActivityEntry>>);
 
   @override
-  _i6.Future<List<_i5.InteractionDistributionEntry>> getInteractionDistribution(
+  _i7.Future<List<_i6.InteractionDistributionEntry>> getInteractionDistribution(
     int? year,
     String? userId,
   ) =>
@@ -256,12 +272,12 @@ class MockStatisticsRepository extends _i1.Mock
             userId,
           ],
         ),
-        returnValue: _i6.Future<List<_i5.InteractionDistributionEntry>>.value(
-            <_i5.InteractionDistributionEntry>[]),
-      ) as _i6.Future<List<_i5.InteractionDistributionEntry>>);
+        returnValue: _i7.Future<List<_i6.InteractionDistributionEntry>>.value(
+            <_i6.InteractionDistributionEntry>[]),
+      ) as _i7.Future<List<_i6.InteractionDistributionEntry>>);
 
   @override
-  _i6.Future<List<_i5.InteractionDistributionEntry>> getCumulativeInteractions(
+  _i7.Future<List<_i6.InteractionDistributionEntry>> getCumulativeInteractions(
     int? year,
     String? userId,
   ) =>
@@ -273,77 +289,77 @@ class MockStatisticsRepository extends _i1.Mock
             userId,
           ],
         ),
-        returnValue: _i6.Future<List<_i5.InteractionDistributionEntry>>.value(
-            <_i5.InteractionDistributionEntry>[]),
-      ) as _i6.Future<List<_i5.InteractionDistributionEntry>>);
+        returnValue: _i7.Future<List<_i6.InteractionDistributionEntry>>.value(
+            <_i6.InteractionDistributionEntry>[]),
+      ) as _i7.Future<List<_i6.InteractionDistributionEntry>>);
 }
 
 /// A class which mocks [AuthService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAuthService extends _i1.Mock implements _i8.AuthService {
+class MockAuthService extends _i1.Mock implements _i9.AuthService {
   MockAuthService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i6.Stream<_i9.User?> get authStateChanges => (super.noSuchMethod(
+  _i7.Stream<_i10.User?> get authStateChanges => (super.noSuchMethod(
         Invocation.getter(#authStateChanges),
-        returnValue: _i6.Stream<_i9.User?>.empty(),
-      ) as _i6.Stream<_i9.User?>);
+        returnValue: _i7.Stream<_i10.User?>.empty(),
+      ) as _i7.Stream<_i10.User?>);
 
   @override
-  _i6.Future<_i9.User?> signInWithGoogle() => (super.noSuchMethod(
+  _i7.Future<_i10.User?> signInWithGoogle() => (super.noSuchMethod(
         Invocation.method(
           #signInWithGoogle,
           [],
         ),
-        returnValue: _i6.Future<_i9.User?>.value(),
-      ) as _i6.Future<_i9.User?>);
+        returnValue: _i7.Future<_i10.User?>.value(),
+      ) as _i7.Future<_i10.User?>);
 
   @override
-  _i6.Future<void> signOut() => (super.noSuchMethod(
+  _i7.Future<void> signOut() => (super.noSuchMethod(
         Invocation.method(
           #signOut,
           [],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<void> runOnboardingIfNeeded(String? userId) => (super.noSuchMethod(
+  _i7.Future<void> runOnboardingIfNeeded(String? userId) => (super.noSuchMethod(
         Invocation.method(
           #runOnboardingIfNeeded,
           [userId],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<void> copyGlobalCategoriesToUserForTest(String? userId) =>
+  _i7.Future<void> copyGlobalCategoriesToUserForTest(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #copyGlobalCategoriesToUserForTest,
           [userId],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 }
 
 /// A class which mocks [ActivityCategoryRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockActivityCategoryRepository extends _i1.Mock
-    implements _i10.ActivityCategoryRepository {
+    implements _i11.ActivityCategoryRepository {
   MockActivityCategoryRepository() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  set cacheInvalidator(_i11.CacheInvalidator? _cacheInvalidator) =>
+  set cacheInvalidator(_i12.CacheInvalidator? _cacheInvalidator) =>
       super.noSuchMethod(
         Invocation.setter(
           #cacheInvalidator,
@@ -353,39 +369,39 @@ class MockActivityCategoryRepository extends _i1.Mock
       );
 
   @override
-  _i6.Stream<List<_i3.ActivityCategory>> getCategories(String? userId) =>
+  _i7.Stream<List<_i3.ActivityCategory>> getCategories(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getCategories,
           [userId],
         ),
-        returnValue: _i6.Stream<List<_i3.ActivityCategory>>.empty(),
-      ) as _i6.Stream<List<_i3.ActivityCategory>>);
+        returnValue: _i7.Stream<List<_i3.ActivityCategory>>.empty(),
+      ) as _i7.Stream<List<_i3.ActivityCategory>>);
 
   @override
-  _i6.Future<void> addCategory(_i3.ActivityCategory? category) =>
+  _i7.Future<void> addCategory(_i3.ActivityCategory? category) =>
       (super.noSuchMethod(
         Invocation.method(
           #addCategory,
           [category],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<void> updateCategory(_i3.ActivityCategory? category) =>
+  _i7.Future<void> updateCategory(_i3.ActivityCategory? category) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateCategory,
           [category],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<void> deleteCategory(
+  _i7.Future<void> deleteCategory(
     String? userId,
     String? categoryId,
   ) =>
@@ -397,12 +413,12 @@ class MockActivityCategoryRepository extends _i1.Mock
             categoryId,
           ],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<void> deleteWithChildren(
+  _i7.Future<void> deleteWithChildren(
     String? userId,
     String? categoryId,
   ) =>
@@ -414,12 +430,12 @@ class MockActivityCategoryRepository extends _i1.Mock
             categoryId,
           ],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<_i3.ActivityCategory> createSelectableCategory({
+  _i7.Future<_i3.ActivityCategory> createSelectableCategory({
     required String? name,
     required String? userId,
   }) =>
@@ -433,7 +449,7 @@ class MockActivityCategoryRepository extends _i1.Mock
           },
         ),
         returnValue:
-            _i6.Future<_i3.ActivityCategory>.value(_FakeActivityCategory_1(
+            _i7.Future<_i3.ActivityCategory>.value(_FakeActivityCategory_1(
           this,
           Invocation.method(
             #createSelectableCategory,
@@ -444,22 +460,22 @@ class MockActivityCategoryRepository extends _i1.Mock
             },
           ),
         )),
-      ) as _i6.Future<_i3.ActivityCategory>);
+      ) as _i7.Future<_i3.ActivityCategory>);
 
   @override
-  _i6.Future<List<_i3.ActivityCategory>> getSelectableCategories(
+  _i7.Future<List<_i3.ActivityCategory>> getSelectableCategories(
           String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getSelectableCategories,
           [userId],
         ),
-        returnValue: _i6.Future<List<_i3.ActivityCategory>>.value(
+        returnValue: _i7.Future<List<_i3.ActivityCategory>>.value(
             <_i3.ActivityCategory>[]),
-      ) as _i6.Future<List<_i3.ActivityCategory>>);
+      ) as _i7.Future<List<_i3.ActivityCategory>>);
 
   @override
-  _i6.Future<List<String>> getAncestorIds(
+  _i7.Future<List<String>> getAncestorIds(
     String? categoryId,
     String? userId,
   ) =>
@@ -471,22 +487,22 @@ class MockActivityCategoryRepository extends _i1.Mock
             userId,
           ],
         ),
-        returnValue: _i6.Future<List<String>>.value(<String>[]),
-      ) as _i6.Future<List<String>>);
+        returnValue: _i7.Future<List<String>>.value(<String>[]),
+      ) as _i7.Future<List<String>>);
 
   @override
-  _i6.Future<List<_i3.ActivityCategory>> getAllCategories(String? userId) =>
+  _i7.Future<List<_i3.ActivityCategory>> getAllCategories(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getAllCategories,
           [userId],
         ),
-        returnValue: _i6.Future<List<_i3.ActivityCategory>>.value(
+        returnValue: _i7.Future<List<_i3.ActivityCategory>>.value(
             <_i3.ActivityCategory>[]),
-      ) as _i6.Future<List<_i3.ActivityCategory>>);
+      ) as _i7.Future<List<_i3.ActivityCategory>>);
 
   @override
-  _i6.Future<List<_i3.ActivityCategory>> getCategoriesByIds(
+  _i7.Future<List<_i3.ActivityCategory>> getCategoriesByIds(
     List<String>? ids,
     String? userId,
   ) =>
@@ -498,21 +514,21 @@ class MockActivityCategoryRepository extends _i1.Mock
             userId,
           ],
         ),
-        returnValue: _i6.Future<List<_i3.ActivityCategory>>.value(
+        returnValue: _i7.Future<List<_i3.ActivityCategory>>.value(
             <_i3.ActivityCategory>[]),
-      ) as _i6.Future<List<_i3.ActivityCategory>>);
+      ) as _i7.Future<List<_i3.ActivityCategory>>);
 }
 
 /// A class which mocks [PersonRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockPersonRepository extends _i1.Mock implements _i12.PersonRepository {
+class MockPersonRepository extends _i1.Mock implements _i13.PersonRepository {
   MockPersonRepository() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  set cacheInvalidator(_i11.CacheInvalidator? _cacheInvalidator) =>
+  set cacheInvalidator(_i12.CacheInvalidator? _cacheInvalidator) =>
       super.noSuchMethod(
         Invocation.setter(
           #cacheInvalidator,
@@ -522,17 +538,17 @@ class MockPersonRepository extends _i1.Mock implements _i12.PersonRepository {
       );
 
   @override
-  _i6.Future<List<_i4.Person>> getPersonsByUser(String? userId) =>
+  _i7.Future<List<_i4.Person>> getPersonsByUser(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPersonsByUser,
           [userId],
         ),
-        returnValue: _i6.Future<List<_i4.Person>>.value(<_i4.Person>[]),
-      ) as _i6.Future<List<_i4.Person>>);
+        returnValue: _i7.Future<List<_i4.Person>>.value(<_i4.Person>[]),
+      ) as _i7.Future<List<_i4.Person>>);
 
   @override
-  _i6.Future<List<_i4.Person>> getPersonsByIds(
+  _i7.Future<List<_i4.Person>> getPersonsByIds(
     List<String>? ids,
     String? userId,
   ) =>
@@ -544,36 +560,36 @@ class MockPersonRepository extends _i1.Mock implements _i12.PersonRepository {
             userId,
           ],
         ),
-        returnValue: _i6.Future<List<_i4.Person>>.value(<_i4.Person>[]),
-      ) as _i6.Future<List<_i4.Person>>);
+        returnValue: _i7.Future<List<_i4.Person>>.value(<_i4.Person>[]),
+      ) as _i7.Future<List<_i4.Person>>);
 
   @override
-  _i6.Future<_i4.Person> addPerson(_i4.Person? person) => (super.noSuchMethod(
+  _i7.Future<_i4.Person> addPerson(_i4.Person? person) => (super.noSuchMethod(
         Invocation.method(
           #addPerson,
           [person],
         ),
-        returnValue: _i6.Future<_i4.Person>.value(_FakePerson_2(
+        returnValue: _i7.Future<_i4.Person>.value(_FakePerson_2(
           this,
           Invocation.method(
             #addPerson,
             [person],
           ),
         )),
-      ) as _i6.Future<_i4.Person>);
+      ) as _i7.Future<_i4.Person>);
 
   @override
-  _i6.Future<void> updatePerson(_i4.Person? person) => (super.noSuchMethod(
+  _i7.Future<void> updatePerson(_i4.Person? person) => (super.noSuchMethod(
         Invocation.method(
           #updatePerson,
           [person],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<bool> isDuplicateName(
+  _i7.Future<bool> isDuplicateName(
     String? userId,
     String? firstName,
     String? lastName, {
@@ -589,11 +605,11 @@ class MockPersonRepository extends _i1.Mock implements _i12.PersonRepository {
           ],
           {#excludeId: excludeId},
         ),
-        returnValue: _i6.Future<bool>.value(false),
-      ) as _i6.Future<bool>);
+        returnValue: _i7.Future<bool>.value(false),
+      ) as _i7.Future<bool>);
 
   @override
-  _i6.Future<void> linkPartner(
+  _i7.Future<void> linkPartner(
     String? userId,
     String? personId,
     String? partnerId,
@@ -607,12 +623,12 @@ class MockPersonRepository extends _i1.Mock implements _i12.PersonRepository {
             partnerId,
           ],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<void> unlinkPartner(
+  _i7.Future<void> unlinkPartner(
     String? userId,
     String? personId,
     String? partnerId,
@@ -626,12 +642,12 @@ class MockPersonRepository extends _i1.Mock implements _i12.PersonRepository {
             partnerId,
           ],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<void> deletePerson(
+  _i7.Future<void> deletePerson(
     String? userId,
     String? personId,
   ) =>
@@ -643,21 +659,21 @@ class MockPersonRepository extends _i1.Mock implements _i12.PersonRepository {
             personId,
           ],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 }
 
 /// A class which mocks [MeetingRepository].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockMeetingRepository extends _i1.Mock implements _i13.MeetingRepository {
+class MockMeetingRepository extends _i1.Mock implements _i14.MeetingRepository {
   MockMeetingRepository() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  set cacheInvalidator(_i11.CacheInvalidator? _cacheInvalidator) =>
+  set cacheInvalidator(_i12.CacheInvalidator? _cacheInvalidator) =>
       super.noSuchMethod(
         Invocation.setter(
           #cacheInvalidator,
@@ -667,52 +683,52 @@ class MockMeetingRepository extends _i1.Mock implements _i13.MeetingRepository {
       );
 
   @override
-  _i6.Future<String> saveMeeting(_i7.Meeting? meeting) => (super.noSuchMethod(
+  _i7.Future<String> saveMeeting(_i8.Meeting? meeting) => (super.noSuchMethod(
         Invocation.method(
           #saveMeeting,
           [meeting],
         ),
-        returnValue: _i6.Future<String>.value(_i14.dummyValue<String>(
+        returnValue: _i7.Future<String>.value(_i15.dummyValue<String>(
           this,
           Invocation.method(
             #saveMeeting,
             [meeting],
           ),
         )),
-      ) as _i6.Future<String>);
+      ) as _i7.Future<String>);
 
   @override
-  _i6.Stream<List<_i7.Meeting>> getMeetingsByUser(String? userId) =>
+  _i7.Stream<List<_i8.Meeting>> getMeetingsByUser(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getMeetingsByUser,
           [userId],
         ),
-        returnValue: _i6.Stream<List<_i7.Meeting>>.empty(),
-      ) as _i6.Stream<List<_i7.Meeting>>);
+        returnValue: _i7.Stream<List<_i8.Meeting>>.empty(),
+      ) as _i7.Stream<List<_i8.Meeting>>);
 
   @override
-  _i6.Future<List<_i7.Meeting>> getAllMeetings(String? userId) =>
+  _i7.Future<List<_i8.Meeting>> getAllMeetings(String? userId) =>
       (super.noSuchMethod(
         Invocation.method(
           #getAllMeetings,
           [userId],
         ),
-        returnValue: _i6.Future<List<_i7.Meeting>>.value(<_i7.Meeting>[]),
-      ) as _i6.Future<List<_i7.Meeting>>);
+        returnValue: _i7.Future<List<_i8.Meeting>>.value(<_i8.Meeting>[]),
+      ) as _i7.Future<List<_i8.Meeting>>);
 
   @override
-  _i6.Future<void> updateMeeting(_i7.Meeting? meeting) => (super.noSuchMethod(
+  _i7.Future<void> updateMeeting(_i8.Meeting? meeting) => (super.noSuchMethod(
         Invocation.method(
           #updateMeeting,
           [meeting],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<void> deleteMeeting(
+  _i7.Future<void> deleteMeeting(
     String? userId,
     String? meetingId,
   ) =>
@@ -724,12 +740,12 @@ class MockMeetingRepository extends _i1.Mock implements _i13.MeetingRepository {
             meetingId,
           ],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<List<_i7.Meeting>> getMeetingsByParticipant(
+  _i7.Future<List<_i8.Meeting>> getMeetingsByParticipant(
     String? userId,
     String? personId,
   ) =>
@@ -741,11 +757,11 @@ class MockMeetingRepository extends _i1.Mock implements _i13.MeetingRepository {
             personId,
           ],
         ),
-        returnValue: _i6.Future<List<_i7.Meeting>>.value(<_i7.Meeting>[]),
-      ) as _i6.Future<List<_i7.Meeting>>);
+        returnValue: _i7.Future<List<_i8.Meeting>>.value(<_i8.Meeting>[]),
+      ) as _i7.Future<List<_i8.Meeting>>);
 
   @override
-  _i6.Future<int> getMeetingsCountForPerson(
+  _i7.Future<int> getMeetingsCountForPerson(
     String? userId,
     String? personId,
   ) =>
@@ -757,11 +773,11 @@ class MockMeetingRepository extends _i1.Mock implements _i13.MeetingRepository {
             personId,
           ],
         ),
-        returnValue: _i6.Future<int>.value(0),
-      ) as _i6.Future<int>);
+        returnValue: _i7.Future<int>.value(0),
+      ) as _i7.Future<int>);
 
   @override
-  _i6.Future<void> replaceCategoryInMeetings(
+  _i7.Future<void> replaceCategoryInMeetings(
     String? userId,
     String? sourceId,
     String? targetId,
@@ -775,12 +791,12 @@ class MockMeetingRepository extends _i1.Mock implements _i13.MeetingRepository {
             targetId,
           ],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 
   @override
-  _i6.Future<_i7.Meeting?> getLastMeetingWithoutNotes(
+  _i7.Future<_i8.Meeting?> getLastMeetingWithoutNotes(
     String? userId,
     DateTime? since,
   ) =>
@@ -792,11 +808,11 @@ class MockMeetingRepository extends _i1.Mock implements _i13.MeetingRepository {
             since,
           ],
         ),
-        returnValue: _i6.Future<_i7.Meeting?>.value(),
-      ) as _i6.Future<_i7.Meeting?>);
+        returnValue: _i7.Future<_i8.Meeting?>.value(),
+      ) as _i7.Future<_i8.Meeting?>);
 
   @override
-  _i6.Future<List<_i7.Meeting>> getRecentMeetingsWithoutNotes(
+  _i7.Future<List<_i8.Meeting>> getRecentMeetingsWithoutNotes(
     String? userId,
     DateTime? since, {
     int? limit = 3,
@@ -810,11 +826,11 @@ class MockMeetingRepository extends _i1.Mock implements _i13.MeetingRepository {
           ],
           {#limit: limit},
         ),
-        returnValue: _i6.Future<List<_i7.Meeting>>.value(<_i7.Meeting>[]),
-      ) as _i6.Future<List<_i7.Meeting>>);
+        returnValue: _i7.Future<List<_i8.Meeting>>.value(<_i8.Meeting>[]),
+      ) as _i7.Future<List<_i8.Meeting>>);
 
   @override
-  _i6.Future<Set<String>> getPersonIdsSeenSince(
+  _i7.Future<Set<String>> getPersonIdsSeenSince(
     String? userId,
     DateTime? since,
   ) =>
@@ -826,11 +842,11 @@ class MockMeetingRepository extends _i1.Mock implements _i13.MeetingRepository {
             since,
           ],
         ),
-        returnValue: _i6.Future<Set<String>>.value(<String>{}),
-      ) as _i6.Future<Set<String>>);
+        returnValue: _i7.Future<Set<String>>.value(<String>{}),
+      ) as _i7.Future<Set<String>>);
 
   @override
-  _i6.Future<List<_i7.Meeting>> getRecentMeetingsByPerson(
+  _i7.Future<List<_i8.Meeting>> getRecentMeetingsByPerson(
     String? userId,
     String? personId, {
     int? limit = 4,
@@ -844,11 +860,11 @@ class MockMeetingRepository extends _i1.Mock implements _i13.MeetingRepository {
           ],
           {#limit: limit},
         ),
-        returnValue: _i6.Future<List<_i7.Meeting>>.value(<_i7.Meeting>[]),
-      ) as _i6.Future<List<_i7.Meeting>>);
+        returnValue: _i7.Future<List<_i8.Meeting>>.value(<_i8.Meeting>[]),
+      ) as _i7.Future<List<_i8.Meeting>>);
 
   @override
-  _i6.Future<void> removePersonFromMeetings(
+  _i7.Future<void> removePersonFromMeetings(
     String? userId,
     String? personId,
   ) =>
@@ -860,31 +876,31 @@ class MockMeetingRepository extends _i1.Mock implements _i13.MeetingRepository {
             personId,
           ],
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 }
 
 /// A class which mocks [LtnsExclusionService].
 ///
 /// See the documentation for Mockito's code generation for more information.
 class MockLtnsExclusionService extends _i1.Mock
-    implements _i15.LtnsExclusionService {
+    implements _i16.LtnsExclusionService {
   MockLtnsExclusionService() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i6.Future<Set<String>> getExcludedIds() => (super.noSuchMethod(
+  _i7.Future<Set<String>> getExcludedIds() => (super.noSuchMethod(
         Invocation.method(
           #getExcludedIds,
           [],
         ),
-        returnValue: _i6.Future<Set<String>>.value(<String>{}),
-      ) as _i6.Future<Set<String>>);
+        returnValue: _i7.Future<Set<String>>.value(<String>{}),
+      ) as _i7.Future<Set<String>>);
 
   @override
-  _i6.Future<void> setExcluded(
+  _i7.Future<void> setExcluded(
     String? personId, {
     required bool? excluded,
   }) =>
@@ -894,7 +910,266 @@ class MockLtnsExclusionService extends _i1.Mock
           [personId],
           {#excluded: excluded},
         ),
-        returnValue: _i6.Future<void>.value(),
-        returnValueForMissingStub: _i6.Future<void>.value(),
-      ) as _i6.Future<void>);
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
+}
+
+/// A class which mocks [FriendsQuestRepository].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockFriendsQuestRepository extends _i1.Mock
+    implements _i17.FriendsQuestRepository {
+  MockFriendsQuestRepository() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  List<_i5.FriendsQuest> getAll(String? userId) => (super.noSuchMethod(
+        Invocation.method(
+          #getAll,
+          [userId],
+        ),
+        returnValue: <_i5.FriendsQuest>[],
+      ) as List<_i5.FriendsQuest>);
+
+  @override
+  _i7.Future<_i5.FriendsQuest> create(
+    String? userId,
+    String? name,
+    List<String>? participantIds,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #create,
+          [
+            userId,
+            name,
+            participantIds,
+          ],
+        ),
+        returnValue: _i7.Future<_i5.FriendsQuest>.value(_FakeFriendsQuest_3(
+          this,
+          Invocation.method(
+            #create,
+            [
+              userId,
+              name,
+              participantIds,
+            ],
+          ),
+        )),
+      ) as _i7.Future<_i5.FriendsQuest>);
+
+  @override
+  _i7.Future<void> delete(
+    String? userId,
+    String? questId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #delete,
+          [
+            userId,
+            questId,
+          ],
+        ),
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
+
+  @override
+  _i7.Future<void> updateQuest(
+    String? userId,
+    _i5.FriendsQuest? quest,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #updateQuest,
+          [
+            userId,
+            quest,
+          ],
+        ),
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
+}
+
+/// A class which mocks [CatchUpTopicRepository].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockCatchUpTopicRepository extends _i1.Mock
+    implements _i18.CatchUpTopicRepository {
+  MockCatchUpTopicRepository() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i7.Future<String> add(
+    String? userId,
+    String? personId,
+    String? text,
+    String? contextLabel,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #add,
+          [
+            userId,
+            personId,
+            text,
+            contextLabel,
+          ],
+        ),
+        returnValue: _i7.Future<String>.value(_i15.dummyValue<String>(
+          this,
+          Invocation.method(
+            #add,
+            [
+              userId,
+              personId,
+              text,
+              contextLabel,
+            ],
+          ),
+        )),
+      ) as _i7.Future<String>);
+
+  @override
+  _i7.Future<List<_i19.CatchUpTopic>> getActive(
+    String? userId,
+    String? personId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getActive,
+          [
+            userId,
+            personId,
+          ],
+        ),
+        returnValue:
+            _i7.Future<List<_i19.CatchUpTopic>>.value(<_i19.CatchUpTopic>[]),
+      ) as _i7.Future<List<_i19.CatchUpTopic>>);
+
+  @override
+  _i7.Future<void> update(
+    String? userId,
+    String? personId,
+    String? topicId,
+    String? text,
+    String? contextLabel,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #update,
+          [
+            userId,
+            personId,
+            topicId,
+            text,
+            contextLabel,
+          ],
+        ),
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
+
+  @override
+  _i7.Future<void> archive(
+    String? userId,
+    String? personId,
+    String? topicId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #archive,
+          [
+            userId,
+            personId,
+            topicId,
+          ],
+        ),
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
+
+  @override
+  _i7.Future<List<_i19.CatchUpTopic>> getArchived(
+    String? userId,
+    String? personId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getArchived,
+          [
+            userId,
+            personId,
+          ],
+        ),
+        returnValue:
+            _i7.Future<List<_i19.CatchUpTopic>>.value(<_i19.CatchUpTopic>[]),
+      ) as _i7.Future<List<_i19.CatchUpTopic>>);
+
+  @override
+  _i7.Future<void> mergeTopics(
+    String? userId,
+    String? personId,
+    String? partnerId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #mergeTopics,
+          [
+            userId,
+            personId,
+            partnerId,
+          ],
+        ),
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
+
+  @override
+  _i7.Future<void> delete(
+    String? userId,
+    String? personId,
+    String? topicId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #delete,
+          [
+            userId,
+            personId,
+            topicId,
+          ],
+        ),
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
+
+  @override
+  _i7.Future<void> applyRedistribution(
+    String? userId,
+    String? personId,
+    String? partnerId,
+    List<_i19.CatchUpTopic>? postLinkTopics,
+    Map<String, _i18.TopicRedistributionDecision>? decisions,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #applyRedistribution,
+          [
+            userId,
+            personId,
+            partnerId,
+            postLinkTopics,
+            decisions,
+          ],
+        ),
+        returnValue: _i7.Future<void>.value(),
+        returnValueForMissingStub: _i7.Future<void>.value(),
+      ) as _i7.Future<void>);
 }


### PR DESCRIPTION
## US-125: Friends-Quest Tasks

**As a** user **I want** catch-up topics from participants to be imported as tasks in my Friends-Quest **so that** I have a complete, deduplicated action list ready for our meeting

### Changes
- `FriendsQuestTask` — new `contextLabel` and `sourcePersonId` fields
- `FriendsQuestRepository` — `updateQuest()`; Hive deep-cast fix via JSON round-trip
- `FriendsQuestProvider` — `addTask`, `editTask`, `deleteTask`, `updateParticipants`, `_importTopicsForQuest` with couple-deduplication
- `FriendsQuestDetailScreen` (NEW) — task list, add/edit dialogs, participant management bottom sheet
- `QuestTaskTile` (NEW) — task row with checkbox, subtitle, edit/delete
- `QuestParticipantsSection` (NEW) — participant management widget for bottom sheet
- 14 new tests (1015 total)

Closes #302
