### PR TITLE
303 us 126 friends quest completion meeting link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to Friendsheet are documented here.
 
 ---
 
+### v4.5.13 — US-126: Friends-Quest Completion & Meeting Link (April 20, 2026)
+- ✅ `lib/presentation/friends_quest/friends_quest_provider.dart` (MODIFIED) — added `MeetingRepository` dep; new methods: `linkToMeeting`, `completeTask` (archives linked Catch-up Topic), `completeQuest` (appends completed task texts as meeting notes, marks quest completed)
+- ✅ `lib/presentation/friends_quest/meeting_picker_sheet.dart` (NEW) — `MeetingPickerSheet`: `DraggableScrollableSheet` with search (name or `dd/mm/yyyy` date), grouped collapsible year → month → meeting list, descending sort, all sections expanded by default
+- ✅ `lib/presentation/friends_quest/quest_add_task_dialog.dart` (NEW) — extracted `showQuestAddTaskDialog` top-level function from detail screen to stay under 300-line limit
+- ✅ `lib/presentation/friends_quest/friends_quest_detail_screen.dart` (MODIFIED) — complete quest `IconButton` in AppBar; meeting link row at top of body; `_showMeetingPickerSheet` delegates to `MeetingPickerSheet`; `_onCompleteQuestTapped` handles linked/unlinked dialog flow; `QuestTaskTile` wired with `onComplete`
+- ✅ `lib/presentation/friends_quest/quest_task_tile.dart` (MODIFIED) — `onComplete: VoidCallback` added; checkbox now interactive for incomplete tasks
+- ✅ `test/presentation/friends_quest/friends_quest_provider_test.dart` (MODIFIED) — +7 tests: `linkToMeeting`, `completeTask` (×3: happy path, archive, no-op), `completeQuest` (×3: marks complete, appends notes, skips update when no meeting)
+- ✅ `test/presentation/friends_quest/meeting_picker_sheet_test.dart` (NEW) — 7 widget tests: search bar, year/month headers, onSelected callback, name filter, date filter, collapse, empty state
+- ✅ `test/presentation/friends_quest/friends_quest_provider_test.mocks.dart` (REGENERATED) — `MockMeetingRepository` added
+- ✅ `test/presentation/friends_quest/quest_task_tile_test.dart` (MODIFIED) — `onComplete` param added to all calls; first test updated for interactive checkbox
+- ✅ `test/presentation/screens/home_screen_test.dart` + `home_screen_test.mocks.dart` (MODIFIED) — `meetingRepo` mock injected into `FriendsQuestProvider` setUp
+- ✅ 1029 Flutter tests passing (+14 new tests)
+
+---
+
 ### v4.5.12 — US-125: Friends-Quest Tasks (April 20, 2026)
 - ✅ `lib/data/models/friends_quest_task.dart` (MODIFIED) — added `contextLabel: String?` and `sourcePersonId: String?` fields
 - ✅ `lib/data/models/friends_quest_task.freezed.dart` + `friends_quest_task.g.dart` (GENERATED) — build_runner output for updated model

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ flutter format --set-exit-if-changed .
 
 **Current Test Status:**
 ```
-✅ All tests passing (1015)
+✅ All tests passing (1029)
 ✅ Code formatted correctly
 ✅ Firebase connected successfully
 ✅ CI/CD pipeline operational
@@ -174,14 +174,13 @@ Project Link: [https://github.com/aleksanderginalski/Friendsheet-App](https://gi
 
 Full version history is available in [CHANGELOG.md](CHANGELOG.md).
 
-### Latest: v4.5.12 — US-125: Friends-Quest Tasks (April 20, 2026)
-- ✅ `FriendsQuestTask` (MODIFIED) — `contextLabel` and `sourcePersonId` fields added
-- ✅ `FriendsQuestRepository` (MODIFIED) — `updateQuest()`; deep Hive cast fix via json round-trip
-- ✅ `FriendsQuestProvider` (MODIFIED) — `addTask`, `editTask`, `deleteTask`, `updateParticipants`, `_importTopicsForQuest` with couple-deduplication
-- ✅ `FriendsQuestDetailScreen` (NEW) — task list, add/edit dialogs, participant management bottom sheet
-- ✅ `QuestTaskTile` (NEW) — task row with read-only checkbox, subtitle, edit/delete actions
-- ✅ `QuestParticipantsSection` (NEW) — participant management widget for bottom sheet
-- ✅ 14 new tests (1015 total)
+### Latest: v4.5.13 — US-126: Friends-Quest Completion & Meeting Link (April 20, 2026)
+- ✅ `FriendsQuestProvider` (MODIFIED) — `linkToMeeting`, `completeTask` (archives Catch-up Topic), `completeQuest` (appends notes to meeting)
+- ✅ `MeetingPickerSheet` (NEW) — grouped collapsible year/month picker with search by name or date
+- ✅ `quest_add_task_dialog.dart` (NEW) — extracted dialog function to keep detail screen under 300 lines
+- ✅ `FriendsQuestDetailScreen` (MODIFIED) — complete quest button, meeting link row, interactive task checkboxes
+- ✅ `QuestTaskTile` (MODIFIED) — interactive checkbox for task completion
+- ✅ 14 new tests (1029 total)
 
 See [CHANGELOG.md](CHANGELOG.md) for all previous versions.
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -4871,7 +4871,7 @@ Firestore SDK on Flutter mobile has built-in offline persistence enabled by defa
 **Story Points:** 5
 **Priority:** P2
 **Labels:** `friends-quest`, `meetings`, `completion`
-**Status:** 📋 Planned
+**Status:** 🔄 In Progress
 **Feature:** FEATURE-032: Friends-Quest
 
 **Acceptance Criteria:**

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -4871,25 +4871,25 @@ Firestore SDK on Flutter mobile has built-in offline persistence enabled by defa
 **Story Points:** 5
 **Priority:** P2
 **Labels:** `friends-quest`, `meetings`, `completion`
-**Status:** 🔄 In Progress
+**Status:** ✅ COMPLETED
 **Feature:** FEATURE-032: Friends-Quest
 
 **Acceptance Criteria:**
-- [ ] User can link a quest to an existing meeting (1 quest : 1 meeting; 1 meeting can have N quests)
-- [ ] Completing a task in the quest → corresponding Catch-up Topic archived on person profile (`isArchived: true`)
-- [ ] "Complete Quest" action on `FriendsQuestDetailScreen`
-- [ ] If quest linked to meeting: all completed tasks added as notes to the linked meeting (via `MeetingRepository`)
-- [ ] If quest NOT linked to meeting: dialog — "Delete all notes?" or "Select a meeting to attach notes"
-- [ ] Completed quest removed from active list (or shown in read-only completed state)
-- [ ] `flutter analyze` clean, `flutter test` pass
+- [x] User can link a quest to an existing meeting (1 quest : 1 meeting; 1 meeting can have N quests)
+- [x] Completing a task in the quest → corresponding Catch-up Topic archived on person profile (`isArchived: true`)
+- [x] "Complete Quest" action on `FriendsQuestDetailScreen`
+- [x] If quest linked to meeting: all completed tasks added as notes to the linked meeting (via `MeetingRepository`)
+- [x] If quest NOT linked to meeting: dialog — "Delete all notes?" or "Select a meeting to attach notes"
+- [x] Completed quest removed from active list (or shown in read-only completed state)
+- [x] `flutter analyze` clean, `flutter test` pass
 
 **Tasks:**
-- [ ] **TASK-126.1:** Implement `linkToMeeting(questId, meetingId)` — validate 1-quest:1-meeting; allow N-quests:1-meeting — 1h
-- [ ] **TASK-126.2:** Add meeting picker UI to `FriendsQuestDetailScreen` — 1.5h
-- [ ] **TASK-126.3:** Implement `completeTask(questId, taskId)` — archives `sourceTopicId` if present — 1h
-- [ ] **TASK-126.4:** Implement `completeQuest(questId)` — push completed tasks as meeting notes via `MeetingRepository`; mark quest completed — 2h
-- [ ] **TASK-126.5:** Build "no meeting linked" completion dialog (delete / select meeting) — 1.5h
-- [ ] **TASK-126.6:** Show completed quest summary (read-only) or remove from active list — 1h
+- [x] **TASK-126.1:** Implement `linkToMeeting(questId, meetingId)` — validate 1-quest:1-meeting; allow N-quests:1-meeting — 1h
+- [x] **TASK-126.2:** Add meeting picker UI to `FriendsQuestDetailScreen` — 1.5h
+- [x] **TASK-126.3:** Implement `completeTask(questId, taskId)` — archives `sourceTopicId` if present — 1h
+- [x] **TASK-126.4:** Implement `completeQuest(questId)` — push completed tasks as meeting notes via `MeetingRepository`; mark quest completed — 2h
+- [x] **TASK-126.5:** Build "no meeting linked" completion dialog (delete / select meeting) — 1.5h
+- [x] **TASK-126.6:** Show completed quest summary (read-only) or remove from active list — 1h
 
 **Dependencies:** US-121, US-125
 **Blocks:** US-127

--- a/docs/TEST_CASES.md
+++ b/docs/TEST_CASES.md
@@ -2055,3 +2055,31 @@ Run after every release or hotfix:
 | UT-125-013 | edit and delete buttons trigger callbacks | both callbacks invoked |
 | UT-125-014 | completed task shows strikethrough text | TextDecoration.lineThrough on text |
 
+---
+
+## US-126 — Friends-Quest Completion & Meeting Link
+
+### Automated tests — `test/presentation/friends_quest/friends_quest_provider_test.dart` (additions)
+
+| ID | Test name | Expected |
+|----|-----------|---------|
+| UT-126-001 | linkToMeeting sets linkedMeetingId on quest | updateQuest called with linkedMeetingId = 'meeting-1' |
+| UT-126-002 | completeTask marks task as completed | updateQuest called with task.isCompleted = true |
+| UT-126-003 | completeTask with sourceTopicId archives the catch-up topic | catchUpRepo.archive called once |
+| UT-126-004 | completeTask on already-completed task is a no-op | updateQuest never called |
+| UT-126-005 | completeQuest marks quest as completed | updateQuest called with isCompleted = true |
+| UT-126-006 | completeQuest appends completed task texts to linked meeting notes | meetingRepo.updateMeeting called with notes = ['Existing note', 'Task A'] |
+| UT-126-007 | completeQuest with no linked meeting skips meeting update | meetingRepo.getAllMeetings never called |
+
+### Automated tests — `test/presentation/friends_quest/meeting_picker_sheet_test.dart` (NEW)
+
+| ID | Test name | Expected |
+|----|-----------|---------|
+| UT-126-008 | shows search bar | TextField present |
+| UT-126-009 | shows year and month headers and meeting names | year, month, meeting names visible |
+| UT-126-010 | tapping a meeting calls onSelected and pops sheet | onSelected receives correct Meeting |
+| UT-126-011 | search by name shows only matching meetings | non-matching items hidden |
+| UT-126-012 | search by date shows matching meeting | date-filtered result visible |
+| UT-126-013 | tapping year header collapses its months | month and meetings hidden after tap |
+| UT-126-014 | shows empty message when search matches nothing | 'No meetings found.' visible |
+

--- a/lib/presentation/friends_quest/friends_quest_detail_screen.dart
+++ b/lib/presentation/friends_quest/friends_quest_detail_screen.dart
@@ -3,11 +3,16 @@ import 'package:provider/provider.dart';
 
 import '../../data/models/friends_quest_task.dart';
 import '../../data/models/person.dart';
+import '../../data/repositories/meeting_repository.dart';
 import '../../data/repositories/person_repository.dart';
 import '../../data/services/auth_service.dart';
 import 'friends_quest_provider.dart';
+import 'meeting_picker_sheet.dart';
+import 'quest_add_task_dialog.dart';
 import 'quest_participants_section.dart';
 import 'quest_task_tile.dart';
+
+enum _CompleteChoice { withoutNotes, selectMeeting }
 
 class FriendsQuestDetailScreen extends StatefulWidget {
   final String questId;
@@ -23,12 +28,16 @@ class _FriendsQuestDetailScreenState extends State<FriendsQuestDetailScreen> {
   late final String _userId;
   Map<String, Person> _personMap = {};
   bool _loadingPersons = true;
+  String? _linkedMeetingName;
 
   @override
   void initState() {
     super.initState();
     _userId = AuthService().currentUserId ?? '';
-    WidgetsBinding.instance.addPostFrameCallback((_) => _loadPersons());
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _loadPersons();
+      _loadLinkedMeetingName();
+    });
   }
 
   Future<void> _loadPersons() async {
@@ -42,6 +51,19 @@ class _FriendsQuestDetailScreenState extends State<FriendsQuestDetailScreen> {
         _personMap = {for (final p in persons) p.id: p};
         _loadingPersons = false;
       });
+    }
+  }
+
+  Future<void> _loadLinkedMeetingName() async {
+    final quest = context.read<FriendsQuestProvider>().quests.firstWhere(
+        (q) => q.id == widget.questId,
+        orElse: () => throw StateError('Quest not found'));
+    if (quest.linkedMeetingId == null) return;
+    final meetings = await MeetingRepository().getAllMeetings(_userId);
+    final matches = meetings.where((m) => m.id == quest.linkedMeetingId);
+    if (mounted) {
+      setState(() =>
+          _linkedMeetingName = matches.isNotEmpty ? matches.first.name : null);
     }
   }
 
@@ -73,87 +95,18 @@ class _FriendsQuestDetailScreenState extends State<FriendsQuestDetailScreen> {
     );
   }
 
-  void _showAddTaskDialog(
-      FriendsQuestProvider provider, List<String> participantIds) {
-    final textController = TextEditingController();
-    final selectedIds = <String>{};
-    var adding = false;
-
-    showDialog<void>(
+  Future<void> _showMeetingPickerSheet(FriendsQuestProvider provider) async {
+    final meetings = await MeetingRepository().getAllMeetings(_userId);
+    if (!mounted) return;
+    showModalBottomSheet<void>(
       context: context,
-      builder: (ctx) => StatefulBuilder(
-        builder: (ctx, setDialog) => AlertDialog(
-          title: const Text('New task'),
-          content: SizedBox(
-            width: double.maxFinite,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                TextField(
-                  controller: textController,
-                  autofocus: true,
-                  maxLength: 200,
-                  decoration: const InputDecoration(labelText: 'Task text'),
-                  onChanged: (_) => setDialog(() {}),
-                ),
-                if (participantIds.isNotEmpty) ...[
-                  const SizedBox(height: 8),
-                  const Text('Assign to (optional)',
-                      style: TextStyle(fontWeight: FontWeight.w600)),
-                  ConstrainedBox(
-                    constraints: const BoxConstraints(maxHeight: 200),
-                    child: ListView(
-                      shrinkWrap: true,
-                      children: participantIds.map((id) {
-                        final name = _personMap[id]?.fullName ?? id;
-                        return CheckboxListTile(
-                          dense: true,
-                          title: Text(name),
-                          value: selectedIds.contains(id),
-                          onChanged: (v) => setDialog(() {
-                            if (v == true) {
-                              selectedIds.add(id);
-                            } else {
-                              selectedIds.remove(id);
-                            }
-                          }),
-                        );
-                      }).toList(),
-                    ),
-                  ),
-                ],
-              ],
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(ctx),
-              child: const Text('CANCEL'),
-            ),
-            TextButton(
-              onPressed: textController.text.trim().isEmpty || adding
-                  ? null
-                  : () async {
-                      setDialog(() => adding = true);
-                      await provider.addTask(
-                        _userId,
-                        widget.questId,
-                        textController.text.trim(),
-                        selectedIds.toList(),
-                      );
-                      if (ctx.mounted) Navigator.pop(ctx);
-                    },
-              child: adding
-                  ? const SizedBox(
-                      width: 16,
-                      height: 16,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                  : const Text('ADD'),
-            ),
-          ],
-        ),
+      isScrollControlled: true,
+      builder: (_) => MeetingPickerSheet(
+        meetings: meetings,
+        onSelected: (m) async {
+          await provider.linkToMeeting(_userId, widget.questId, m.id);
+          if (mounted) setState(() => _linkedMeetingName = m.name);
+        },
       ),
     );
   }
@@ -207,6 +160,50 @@ class _FriendsQuestDetailScreenState extends State<FriendsQuestDetailScreen> {
     );
   }
 
+  Future<void> _onCompleteQuestTapped(FriendsQuestProvider provider) async {
+    final quest = provider.quests.firstWhere((q) => q.id == widget.questId);
+    if (quest.linkedMeetingId != null) {
+      await provider.completeQuest(_userId, widget.questId);
+      if (mounted) Navigator.pop(context);
+      return;
+    }
+    final choice = await showDialog<_CompleteChoice>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Complete Quest'),
+        content: const Text(
+          'This quest is not linked to a meeting. '
+          'Complete without saving notes, or select a meeting first?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () =>
+                Navigator.pop(context, _CompleteChoice.withoutNotes),
+            child: const Text('WITHOUT NOTES'),
+          ),
+          TextButton(
+            onPressed: () =>
+                Navigator.pop(context, _CompleteChoice.selectMeeting),
+            child: const Text('SELECT MEETING'),
+          ),
+        ],
+      ),
+    );
+    if (!mounted) return;
+    if (choice == _CompleteChoice.withoutNotes) {
+      await provider.completeQuest(_userId, widget.questId);
+      if (mounted) Navigator.pop(context);
+    } else if (choice == _CompleteChoice.selectMeeting) {
+      await _showMeetingPickerSheet(provider);
+      if (!mounted) return;
+      final updated = provider.quests.firstWhere((q) => q.id == widget.questId);
+      if (updated.linkedMeetingId != null) {
+        await provider.completeQuest(_userId, widget.questId);
+        if (mounted) Navigator.pop(context);
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final provider = context.watch<FriendsQuestProvider>();
@@ -230,37 +227,75 @@ class _FriendsQuestDetailScreenState extends State<FriendsQuestDetailScreen> {
                 ? null
                 : () => _showParticipantsSheet(provider, quest.participantIds),
           ),
+          IconButton(
+            icon: const Icon(Icons.check_circle_outline),
+            tooltip: 'Complete quest',
+            onPressed: () => _onCompleteQuestTapped(provider),
+          ),
         ],
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () => _showAddTaskDialog(provider, quest.participantIds),
+        onPressed: () => showQuestAddTaskDialog(
+          context,
+          provider: provider,
+          userId: _userId,
+          questId: widget.questId,
+          personMap: _personMap,
+          participantIds: quest.participantIds,
+        ),
         backgroundColor: const Color(0xFF4CAF50),
         foregroundColor: Colors.white,
         child: const Icon(Icons.add),
       ),
       body: _loadingPersons
           ? const Center(child: CircularProgressIndicator())
-          : quest.tasks.isEmpty
-              ? const Center(
-                  child: Text(
-                    'No tasks yet. Add one with the + button.',
-                    style: TextStyle(color: Colors.grey),
-                    textAlign: TextAlign.center,
-                  ),
-                )
-              : ListView.builder(
-                  itemCount: quest.tasks.length,
-                  itemBuilder: (_, i) {
-                    final task = quest.tasks[i];
-                    return QuestTaskTile(
-                      task: task,
-                      personMap: _personMap,
-                      onEdit: () => _showEditTaskDialog(provider, task),
-                      onDelete: () =>
-                          provider.deleteTask(_userId, widget.questId, task.id),
-                    );
-                  },
+          : Column(
+              children: [
+                Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                  child: quest.linkedMeetingId == null
+                      ? TextButton.icon(
+                          onPressed: () => _showMeetingPickerSheet(provider),
+                          icon: const Icon(Icons.link),
+                          label: const Text('Link to meeting'),
+                        )
+                      : ListTile(
+                          dense: true,
+                          leading:
+                              const Icon(Icons.link, color: Color(0xFF4CAF50)),
+                          title: Text(_linkedMeetingName ?? 'Meeting linked'),
+                          subtitle: const Text('Tap to change'),
+                          onTap: () => _showMeetingPickerSheet(provider),
+                        ),
                 ),
+                Expanded(
+                  child: quest.tasks.isEmpty
+                      ? const Center(
+                          child: Text(
+                            'No tasks yet. Add one with the + button.',
+                            style: TextStyle(color: Colors.grey),
+                            textAlign: TextAlign.center,
+                          ),
+                        )
+                      : ListView.builder(
+                          itemCount: quest.tasks.length,
+                          itemBuilder: (_, i) {
+                            final task = quest.tasks[i];
+                            return QuestTaskTile(
+                              task: task,
+                              personMap: _personMap,
+                              onComplete: () => provider.completeTask(
+                                  _userId, widget.questId, task.id),
+                              onEdit: () => _showEditTaskDialog(provider, task),
+                              onDelete: () => provider.deleteTask(
+                                  _userId, widget.questId, task.id),
+                            );
+                          },
+                        ),
+                ),
+              ],
+            ),
     );
   }
 }

--- a/lib/presentation/friends_quest/friends_quest_provider.dart
+++ b/lib/presentation/friends_quest/friends_quest_provider.dart
@@ -4,14 +4,17 @@ import 'package:uuid/uuid.dart';
 import '../../data/models/catch_up_topic.dart';
 import '../../data/models/friends_quest.dart';
 import '../../data/models/friends_quest_task.dart';
+import '../../data/models/meeting.dart';
 import '../../data/repositories/catch_up_topic_repository.dart';
 import '../../data/repositories/friends_quest_repository.dart';
+import '../../data/repositories/meeting_repository.dart';
 import '../../data/repositories/person_repository.dart';
 
 class FriendsQuestProvider extends ChangeNotifier {
   final FriendsQuestRepository _repository;
   final CatchUpTopicRepository _catchUpRepo;
   final PersonRepository _personRepo;
+  final MeetingRepository _meetingRepo;
 
   static const _uuid = Uuid();
 
@@ -22,9 +25,11 @@ class FriendsQuestProvider extends ChangeNotifier {
     FriendsQuestRepository? repository,
     CatchUpTopicRepository? catchUpRepo,
     PersonRepository? personRepo,
+    MeetingRepository? meetingRepo,
   })  : _repository = repository ?? FriendsQuestRepository(),
         _catchUpRepo = catchUpRepo ?? CatchUpTopicRepository(),
-        _personRepo = personRepo ?? PersonRepository();
+        _personRepo = personRepo ?? PersonRepository(),
+        _meetingRepo = meetingRepo ?? MeetingRepository();
 
   List<FriendsQuest> get quests => _quests;
   List<FriendsQuest> get activeQuests =>
@@ -266,6 +271,52 @@ class FriendsQuestProvider extends ChangeNotifier {
     }
 
     await _repository.updateQuest(userId, quest.copyWith(tasks: allTasks));
+    _quests = _repository.getAll(userId);
+    notifyListeners();
+  }
+
+  Future<void> linkToMeeting(
+      String userId, String questId, String meetingId) async {
+    final quest = _quests.firstWhere((q) => q.id == questId);
+    await _repository.updateQuest(
+        userId, quest.copyWith(linkedMeetingId: meetingId));
+    _quests = _repository.getAll(userId);
+    notifyListeners();
+  }
+
+  Future<void> completeTask(
+      String userId, String questId, String taskId) async {
+    final quest = _quests.firstWhere((q) => q.id == questId);
+    final task = quest.tasks.firstWhere((t) => t.id == taskId);
+    if (task.isCompleted) return;
+    if (task.sourceTopicId != null && task.sourcePersonId != null) {
+      try {
+        await _catchUpRepo.archive(
+            userId, task.sourcePersonId!, task.sourceTopicId!);
+      } catch (_) {}
+    }
+    final updated = quest.tasks
+        .map((t) => t.id == taskId ? t.copyWith(isCompleted: true) : t)
+        .toList();
+    await _repository.updateQuest(userId, quest.copyWith(tasks: updated));
+    _quests = _repository.getAll(userId);
+    notifyListeners();
+  }
+
+  Future<void> completeQuest(String userId, String questId) async {
+    final quest = _quests.firstWhere((q) => q.id == questId);
+    final done = quest.tasks.where((t) => t.isCompleted).toList();
+    if (quest.linkedMeetingId != null && done.isNotEmpty) {
+      final all = await _meetingRepo.getAllMeetings(userId);
+      final matches = all.where((m) => m.id == quest.linkedMeetingId);
+      final Meeting? m = matches.isNotEmpty ? matches.first : null;
+      if (m != null) {
+        await _meetingRepo.updateMeeting(
+          m.copyWith(notes: [...m.notes, ...done.map((t) => t.text)]),
+        );
+      }
+    }
+    await _repository.updateQuest(userId, quest.copyWith(isCompleted: true));
     _quests = _repository.getAll(userId);
     notifyListeners();
   }

--- a/lib/presentation/friends_quest/meeting_picker_sheet.dart
+++ b/lib/presentation/friends_quest/meeting_picker_sheet.dart
@@ -1,0 +1,213 @@
+import 'package:flutter/material.dart';
+
+import '../../data/models/meeting.dart';
+
+const _monthNames = [
+  '',
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+class MeetingPickerSheet extends StatefulWidget {
+  final List<Meeting> meetings;
+  final void Function(Meeting) onSelected;
+
+  const MeetingPickerSheet({
+    super.key,
+    required this.meetings,
+    required this.onSelected,
+  });
+
+  @override
+  State<MeetingPickerSheet> createState() => _MeetingPickerSheetState();
+}
+
+class _MeetingPickerSheetState extends State<MeetingPickerSheet> {
+  final _searchController = TextEditingController();
+  String _query = '';
+  late final Set<int> _expandedYears;
+  late final Set<String> _expandedMonths;
+
+  @override
+  void initState() {
+    super.initState();
+    // Expand all years and months by default so meetings are immediately visible.
+    _expandedYears = widget.meetings.map((m) => m.date.year).toSet();
+    _expandedMonths = widget.meetings
+        .map((m) => _monthKey(m.date.year, m.date.month))
+        .toSet();
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  String _monthKey(int year, int month) =>
+      '$year-${month.toString().padLeft(2, '0')}';
+
+  List<Meeting> get _filtered {
+    final q = _query.trim().toLowerCase();
+    if (q.isEmpty) return widget.meetings;
+    return widget.meetings.where((m) {
+      if (m.name.toLowerCase().contains(q)) return true;
+      final dateStr =
+          '${m.date.day.toString().padLeft(2, '0')}/${m.date.month.toString().padLeft(2, '0')}/${m.date.year}';
+      return dateStr.contains(q);
+    }).toList();
+  }
+
+  // Groups [meetings] by year → month, both sorted descending.
+  // Within each month meetings are sorted by date descending.
+  Map<int, Map<int, List<Meeting>>> _group(List<Meeting> meetings) {
+    final sorted = [...meetings]..sort((a, b) => b.date.compareTo(a.date));
+    final map = <int, Map<int, List<Meeting>>>{};
+    for (final m in sorted) {
+      map
+          .putIfAbsent(m.date.year, () => {})
+          .putIfAbsent(m.date.month, () => [])
+          .add(m);
+    }
+    final years = map.keys.toList()..sort((a, b) => b.compareTo(a));
+    return {
+      for (final y in years)
+        y: {
+          for (final mo
+              in (map[y]!.keys.toList()..sort((a, b) => b.compareTo(a))))
+            mo: map[y]![mo]!,
+        },
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final filtered = _filtered;
+    final isSearching = _query.trim().isNotEmpty;
+
+    return DraggableScrollableSheet(
+      expand: false,
+      initialChildSize: 0.6,
+      maxChildSize: 0.9,
+      builder: (_, scrollController) => Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+            child: TextField(
+              controller: _searchController,
+              decoration: const InputDecoration(
+                hintText: 'Search by name or date (dd/mm/yyyy)…',
+                prefixIcon: Icon(Icons.search),
+                border: OutlineInputBorder(),
+                isDense: true,
+              ),
+              onChanged: (v) => setState(() => _query = v),
+            ),
+          ),
+          Expanded(
+            child: isSearching
+                ? _buildFlatList(filtered, scrollController)
+                : _buildGroupedList(_group(filtered), scrollController),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFlatList(List<Meeting> meetings, ScrollController controller) {
+    if (meetings.isEmpty) {
+      return const Center(
+        child: Text('No meetings found.', style: TextStyle(color: Colors.grey)),
+      );
+    }
+    return ListView.builder(
+      controller: controller,
+      itemCount: meetings.length,
+      itemBuilder: (_, i) => _meetingTile(meetings[i]),
+    );
+  }
+
+  Widget _buildGroupedList(
+      Map<int, Map<int, List<Meeting>>> grouped, ScrollController controller) {
+    return ListView(
+      controller: controller,
+      children: [
+        for (final yearEntry in grouped.entries) ...[
+          ListTile(
+            tileColor: const Color(0xFFE8F5E9),
+            title: Text(
+              yearEntry.key.toString(),
+              style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
+            ),
+            trailing: Icon(_expandedYears.contains(yearEntry.key)
+                ? Icons.expand_less
+                : Icons.expand_more),
+            onTap: () => setState(() {
+              if (_expandedYears.contains(yearEntry.key)) {
+                _expandedYears.remove(yearEntry.key);
+              } else {
+                _expandedYears.add(yearEntry.key);
+              }
+            }),
+          ),
+          if (_expandedYears.contains(yearEntry.key))
+            for (final monthEntry in yearEntry.value.entries) ...[
+              ListTile(
+                dense: true,
+                contentPadding: const EdgeInsets.symmetric(horizontal: 24),
+                title: Text(
+                  _monthNames[monthEntry.key],
+                  style: const TextStyle(color: Colors.grey, fontSize: 13),
+                ),
+                trailing: Icon(
+                  _expandedMonths
+                          .contains(_monthKey(yearEntry.key, monthEntry.key))
+                      ? Icons.expand_less
+                      : Icons.expand_more,
+                  size: 18,
+                  color: Colors.grey,
+                ),
+                onTap: () => setState(() {
+                  final key = _monthKey(yearEntry.key, monthEntry.key);
+                  if (_expandedMonths.contains(key)) {
+                    _expandedMonths.remove(key);
+                  } else {
+                    _expandedMonths.add(key);
+                  }
+                }),
+              ),
+              if (_expandedMonths
+                  .contains(_monthKey(yearEntry.key, monthEntry.key)))
+                for (final m in monthEntry.value) _meetingTile(m, indent: true),
+            ],
+        ],
+      ],
+    );
+  }
+
+  Widget _meetingTile(Meeting m, {bool indent = false}) {
+    return ListTile(
+      contentPadding: EdgeInsets.symmetric(horizontal: indent ? 40 : 16),
+      title: Text(m.name),
+      subtitle: Text(
+        '${m.date.day.toString().padLeft(2, '0')}/'
+        '${m.date.month.toString().padLeft(2, '0')}/'
+        '${m.date.year}',
+      ),
+      onTap: () {
+        Navigator.of(context).pop();
+        widget.onSelected(m);
+      },
+    );
+  }
+}

--- a/lib/presentation/friends_quest/quest_add_task_dialog.dart
+++ b/lib/presentation/friends_quest/quest_add_task_dialog.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+
+import '../../data/models/person.dart';
+import 'friends_quest_provider.dart';
+
+void showQuestAddTaskDialog(
+  BuildContext context, {
+  required FriendsQuestProvider provider,
+  required String userId,
+  required String questId,
+  required Map<String, Person> personMap,
+  required List<String> participantIds,
+}) {
+  final textController = TextEditingController();
+  final selectedIds = <String>{};
+  var adding = false;
+
+  showDialog<void>(
+    context: context,
+    builder: (ctx) => StatefulBuilder(
+      builder: (ctx, setDialog) => AlertDialog(
+        title: const Text('New task'),
+        content: SizedBox(
+          width: double.maxFinite,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TextField(
+                controller: textController,
+                autofocus: true,
+                maxLength: 200,
+                decoration: const InputDecoration(labelText: 'Task text'),
+                onChanged: (_) => setDialog(() {}),
+              ),
+              if (participantIds.isNotEmpty) ...[
+                const SizedBox(height: 8),
+                const Text(
+                  'Assign to (optional)',
+                  style: TextStyle(fontWeight: FontWeight.w600),
+                ),
+                ConstrainedBox(
+                  constraints: const BoxConstraints(maxHeight: 200),
+                  child: ListView(
+                    shrinkWrap: true,
+                    children: participantIds.map((id) {
+                      final name = personMap[id]?.fullName ?? id;
+                      return CheckboxListTile(
+                        dense: true,
+                        title: Text(name),
+                        value: selectedIds.contains(id),
+                        onChanged: (v) => setDialog(() {
+                          if (v == true) {
+                            selectedIds.add(id);
+                          } else {
+                            selectedIds.remove(id);
+                          }
+                        }),
+                      );
+                    }).toList(),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('CANCEL'),
+          ),
+          TextButton(
+            onPressed: textController.text.trim().isEmpty || adding
+                ? null
+                : () async {
+                    setDialog(() => adding = true);
+                    await provider.addTask(
+                      userId,
+                      questId,
+                      textController.text.trim(),
+                      selectedIds.toList(),
+                    );
+                    if (ctx.mounted) Navigator.pop(ctx);
+                  },
+            child: adding
+                ? const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Text('ADD'),
+          ),
+        ],
+      ),
+    ),
+  );
+}

--- a/lib/presentation/friends_quest/quest_task_tile.dart
+++ b/lib/presentation/friends_quest/quest_task_tile.dart
@@ -8,6 +8,7 @@ class QuestTaskTile extends StatelessWidget {
   final Map<String, Person> personMap;
   final VoidCallback onEdit;
   final VoidCallback onDelete;
+  final VoidCallback onComplete;
 
   const QuestTaskTile({
     super.key,
@@ -15,6 +16,7 @@ class QuestTaskTile extends StatelessWidget {
     required this.personMap,
     required this.onEdit,
     required this.onDelete,
+    required this.onComplete,
   });
 
   String _subtitle() {
@@ -36,7 +38,7 @@ class QuestTaskTile extends StatelessWidget {
     return ListTile(
       leading: Checkbox(
         value: task.isCompleted,
-        onChanged: null,
+        onChanged: task.isCompleted ? null : (_) => onComplete(),
       ),
       title: Text(
         task.text,

--- a/test/presentation/friends_quest/friends_quest_provider_test.dart
+++ b/test/presentation/friends_quest/friends_quest_provider_test.dart
@@ -2,9 +2,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:friendsheet/data/models/catch_up_topic.dart';
 import 'package:friendsheet/data/models/friends_quest.dart';
 import 'package:friendsheet/data/models/friends_quest_task.dart';
+import 'package:friendsheet/data/models/meeting.dart';
 import 'package:friendsheet/data/models/person.dart';
 import 'package:friendsheet/data/repositories/catch_up_topic_repository.dart';
 import 'package:friendsheet/data/repositories/friends_quest_repository.dart';
+import 'package:friendsheet/data/repositories/meeting_repository.dart';
 import 'package:friendsheet/data/repositories/person_repository.dart';
 import 'package:friendsheet/presentation/friends_quest/friends_quest_provider.dart';
 import 'package:mockito/annotations.dart';
@@ -12,12 +14,17 @@ import 'package:mockito/mockito.dart';
 
 import 'friends_quest_provider_test.mocks.dart';
 
-@GenerateMocks(
-    [FriendsQuestRepository, CatchUpTopicRepository, PersonRepository])
+@GenerateMocks([
+  FriendsQuestRepository,
+  CatchUpTopicRepository,
+  PersonRepository,
+  MeetingRepository,
+])
 void main() {
   late MockFriendsQuestRepository mockRepo;
   late MockCatchUpTopicRepository mockCatchUpRepo;
   late MockPersonRepository mockPersonRepo;
+  late MockMeetingRepository mockMeetingRepo;
   late FriendsQuestProvider provider;
 
   final activeQuest = FriendsQuest(
@@ -38,10 +45,12 @@ void main() {
     mockRepo = MockFriendsQuestRepository();
     mockCatchUpRepo = MockCatchUpTopicRepository();
     mockPersonRepo = MockPersonRepository();
+    mockMeetingRepo = MockMeetingRepository();
     provider = FriendsQuestProvider(
       repository: mockRepo,
       catchUpRepo: mockCatchUpRepo,
       personRepo: mockPersonRepo,
+      meetingRepo: mockMeetingRepo,
     );
   });
 
@@ -257,6 +266,122 @@ void main() {
       expect(savedQuest.tasks.first.sourceTopicId, 'topic-1');
       expect(savedQuest.tasks.first.assignedPersonIds, ['p1']);
       expect(provider.isLoading, false);
+    });
+
+    test('linkToMeeting sets linkedMeetingId on quest', () async {
+      when(mockRepo.getAll('u1')).thenReturn([activeQuest]);
+      provider.loadQuests('u1');
+
+      await provider.linkToMeeting('u1', 'q1', 'meeting-1');
+
+      final captured = verify(mockRepo.updateQuest('u1', captureAny)).captured;
+      final saved = captured.last as FriendsQuest;
+      expect(saved.linkedMeetingId, 'meeting-1');
+    });
+
+    test('completeTask marks task as completed', () async {
+      final questWithTask = activeQuest.copyWith(tasks: [
+        const FriendsQuestTask(id: 't1', text: 'Do something'),
+      ]);
+      when(mockRepo.getAll('u1')).thenReturn([questWithTask]);
+      provider.loadQuests('u1');
+
+      await provider.completeTask('u1', 'q1', 't1');
+
+      final captured = verify(mockRepo.updateQuest('u1', captureAny)).captured;
+      final saved = captured.last as FriendsQuest;
+      expect(saved.tasks.first.isCompleted, true);
+    });
+
+    test('completeTask with sourceTopicId archives the catch-up topic',
+        () async {
+      final questWithTask = activeQuest.copyWith(tasks: [
+        const FriendsQuestTask(
+          id: 't1',
+          text: 'Talk to Alice',
+          sourceTopicId: 'topic-1',
+          sourcePersonId: 'p1',
+        ),
+      ]);
+      when(mockRepo.getAll('u1')).thenReturn([questWithTask]);
+      provider.loadQuests('u1');
+      when(mockCatchUpRepo.archive('u1', 'p1', 'topic-1'))
+          .thenAnswer((_) async {});
+
+      await provider.completeTask('u1', 'q1', 't1');
+
+      verify(mockCatchUpRepo.archive('u1', 'p1', 'topic-1')).called(1);
+    });
+
+    test('completeTask on already-completed task is a no-op', () async {
+      final questWithTask = activeQuest.copyWith(tasks: [
+        const FriendsQuestTask(id: 't1', text: 'Done', isCompleted: true),
+      ]);
+      when(mockRepo.getAll('u1')).thenReturn([questWithTask]);
+      provider.loadQuests('u1');
+
+      await provider.completeTask('u1', 'q1', 't1');
+
+      verifyNever(mockRepo.updateQuest(any, any));
+    });
+
+    test('completeQuest marks quest as completed', () async {
+      when(mockRepo.getAll('u1')).thenReturn([activeQuest]);
+      provider.loadQuests('u1');
+      when(mockMeetingRepo.getAllMeetings('u1')).thenAnswer((_) async => []);
+
+      await provider.completeQuest('u1', 'q1');
+
+      final captured = verify(mockRepo.updateQuest('u1', captureAny)).captured;
+      final saved = captured.last as FriendsQuest;
+      expect(saved.isCompleted, true);
+    });
+
+    test('completeQuest appends completed task texts to linked meeting notes',
+        () async {
+      final meeting = Meeting(
+        id: 'm1',
+        userId: 'u1',
+        name: 'Coffee',
+        date: DateTime(2026),
+        weight: 3,
+        participantIds: const [],
+        notes: const ['Existing note'],
+        createdAt: DateTime(2026),
+        updatedAt: DateTime(2026),
+      );
+      final linkedQuest = FriendsQuest(
+        id: 'q1',
+        name: 'Weekend crew',
+        participantIds: const ['p1'],
+        createdAt: DateTime(2026),
+        linkedMeetingId: 'm1',
+        tasks: const [
+          FriendsQuestTask(id: 't1', text: 'Task A', isCompleted: true),
+          FriendsQuestTask(id: 't2', text: 'Task B', isCompleted: false),
+        ],
+      );
+      when(mockRepo.getAll('u1')).thenReturn([linkedQuest]);
+      provider.loadQuests('u1');
+      when(mockMeetingRepo.getAllMeetings('u1'))
+          .thenAnswer((_) async => [meeting]);
+      when(mockMeetingRepo.updateMeeting(any)).thenAnswer((_) async {});
+
+      await provider.completeQuest('u1', 'q1');
+
+      final captured =
+          verify(mockMeetingRepo.updateMeeting(captureAny)).captured;
+      final updated = captured.first as Meeting;
+      expect(updated.notes, ['Existing note', 'Task A']);
+    });
+
+    test('completeQuest with no linked meeting skips meeting update', () async {
+      when(mockRepo.getAll('u1')).thenReturn([activeQuest]);
+      provider.loadQuests('u1');
+
+      await provider.completeQuest('u1', 'q1');
+
+      verifyNever(mockMeetingRepo.getAllMeetings(any));
     });
   });
 }

--- a/test/presentation/friends_quest/friends_quest_provider_test.mocks.dart
+++ b/test/presentation/friends_quest/friends_quest_provider_test.mocks.dart
@@ -7,12 +7,14 @@ import 'dart:async' as _i5;
 
 import 'package:friendsheet/data/models/catch_up_topic.dart' as _i8;
 import 'package:friendsheet/data/models/friends_quest.dart' as _i2;
+import 'package:friendsheet/data/models/meeting.dart' as _i12;
 import 'package:friendsheet/data/models/person.dart' as _i3;
 import 'package:friendsheet/data/repositories/cache_invalidator.dart' as _i10;
 import 'package:friendsheet/data/repositories/catch_up_topic_repository.dart'
     as _i6;
 import 'package:friendsheet/data/repositories/friends_quest_repository.dart'
     as _i4;
+import 'package:friendsheet/data/repositories/meeting_repository.dart' as _i11;
 import 'package:friendsheet/data/repositories/person_repository.dart' as _i9;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:mockito/src/dummies.dart' as _i7;
@@ -445,6 +447,223 @@ class MockPersonRepository extends _i1.Mock implements _i9.PersonRepository {
       (super.noSuchMethod(
         Invocation.method(
           #deletePerson,
+          [
+            userId,
+            personId,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+}
+
+/// A class which mocks [MeetingRepository].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockMeetingRepository extends _i1.Mock implements _i11.MeetingRepository {
+  MockMeetingRepository() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  set cacheInvalidator(_i10.CacheInvalidator? _cacheInvalidator) =>
+      super.noSuchMethod(
+        Invocation.setter(
+          #cacheInvalidator,
+          _cacheInvalidator,
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i5.Future<String> saveMeeting(_i12.Meeting? meeting) => (super.noSuchMethod(
+        Invocation.method(
+          #saveMeeting,
+          [meeting],
+        ),
+        returnValue: _i5.Future<String>.value(_i7.dummyValue<String>(
+          this,
+          Invocation.method(
+            #saveMeeting,
+            [meeting],
+          ),
+        )),
+      ) as _i5.Future<String>);
+
+  @override
+  _i5.Stream<List<_i12.Meeting>> getMeetingsByUser(String? userId) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getMeetingsByUser,
+          [userId],
+        ),
+        returnValue: _i5.Stream<List<_i12.Meeting>>.empty(),
+      ) as _i5.Stream<List<_i12.Meeting>>);
+
+  @override
+  _i5.Future<List<_i12.Meeting>> getAllMeetings(String? userId) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getAllMeetings,
+          [userId],
+        ),
+        returnValue: _i5.Future<List<_i12.Meeting>>.value(<_i12.Meeting>[]),
+      ) as _i5.Future<List<_i12.Meeting>>);
+
+  @override
+  _i5.Future<void> updateMeeting(_i12.Meeting? meeting) => (super.noSuchMethod(
+        Invocation.method(
+          #updateMeeting,
+          [meeting],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<void> deleteMeeting(
+    String? userId,
+    String? meetingId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #deleteMeeting,
+          [
+            userId,
+            meetingId,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<List<_i12.Meeting>> getMeetingsByParticipant(
+    String? userId,
+    String? personId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getMeetingsByParticipant,
+          [
+            userId,
+            personId,
+          ],
+        ),
+        returnValue: _i5.Future<List<_i12.Meeting>>.value(<_i12.Meeting>[]),
+      ) as _i5.Future<List<_i12.Meeting>>);
+
+  @override
+  _i5.Future<int> getMeetingsCountForPerson(
+    String? userId,
+    String? personId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getMeetingsCountForPerson,
+          [
+            userId,
+            personId,
+          ],
+        ),
+        returnValue: _i5.Future<int>.value(0),
+      ) as _i5.Future<int>);
+
+  @override
+  _i5.Future<void> replaceCategoryInMeetings(
+    String? userId,
+    String? sourceId,
+    String? targetId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #replaceCategoryInMeetings,
+          [
+            userId,
+            sourceId,
+            targetId,
+          ],
+        ),
+        returnValue: _i5.Future<void>.value(),
+        returnValueForMissingStub: _i5.Future<void>.value(),
+      ) as _i5.Future<void>);
+
+  @override
+  _i5.Future<_i12.Meeting?> getLastMeetingWithoutNotes(
+    String? userId,
+    DateTime? since,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getLastMeetingWithoutNotes,
+          [
+            userId,
+            since,
+          ],
+        ),
+        returnValue: _i5.Future<_i12.Meeting?>.value(),
+      ) as _i5.Future<_i12.Meeting?>);
+
+  @override
+  _i5.Future<List<_i12.Meeting>> getRecentMeetingsWithoutNotes(
+    String? userId,
+    DateTime? since, {
+    int? limit = 3,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getRecentMeetingsWithoutNotes,
+          [
+            userId,
+            since,
+          ],
+          {#limit: limit},
+        ),
+        returnValue: _i5.Future<List<_i12.Meeting>>.value(<_i12.Meeting>[]),
+      ) as _i5.Future<List<_i12.Meeting>>);
+
+  @override
+  _i5.Future<Set<String>> getPersonIdsSeenSince(
+    String? userId,
+    DateTime? since,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getPersonIdsSeenSince,
+          [
+            userId,
+            since,
+          ],
+        ),
+        returnValue: _i5.Future<Set<String>>.value(<String>{}),
+      ) as _i5.Future<Set<String>>);
+
+  @override
+  _i5.Future<List<_i12.Meeting>> getRecentMeetingsByPerson(
+    String? userId,
+    String? personId, {
+    int? limit = 4,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getRecentMeetingsByPerson,
+          [
+            userId,
+            personId,
+          ],
+          {#limit: limit},
+        ),
+        returnValue: _i5.Future<List<_i12.Meeting>>.value(<_i12.Meeting>[]),
+      ) as _i5.Future<List<_i12.Meeting>>);
+
+  @override
+  _i5.Future<void> removePersonFromMeetings(
+    String? userId,
+    String? personId,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #removePersonFromMeetings,
           [
             userId,
             personId,

--- a/test/presentation/friends_quest/meeting_picker_sheet_test.dart
+++ b/test/presentation/friends_quest/meeting_picker_sheet_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:friendsheet/data/models/meeting.dart';
+import 'package:friendsheet/presentation/friends_quest/meeting_picker_sheet.dart';
+
+void main() {
+  Meeting makeMeeting({
+    required String id,
+    required String name,
+    required DateTime date,
+  }) =>
+      Meeting(
+        id: id,
+        userId: 'u1',
+        name: name,
+        date: date,
+        weight: 3,
+        participantIds: const [],
+        createdAt: DateTime(2026),
+        updatedAt: DateTime(2026),
+      );
+
+  final meetings = [
+    makeMeeting(id: 'm1', name: 'Coffee', date: DateTime(2026, 4, 16)),
+    makeMeeting(id: 'm2', name: 'Lunch', date: DateTime(2026, 4, 2)),
+    makeMeeting(id: 'm3', name: 'Dinner', date: DateTime(2025, 12, 1)),
+  ];
+
+  Widget wrap(Widget child) => MaterialApp(
+        home: Scaffold(body: child),
+      );
+
+  Future<void> pumpSheet(
+    WidgetTester tester, {
+    List<Meeting> data = const [],
+    void Function(Meeting)? onSelected,
+  }) async {
+    await tester.pumpWidget(wrap(MeetingPickerSheet(
+      meetings: data,
+      onSelected: onSelected ?? (_) {},
+    )));
+    await tester.pump();
+  }
+
+  group('MeetingPickerSheet', () {
+    testWidgets('shows search bar', (tester) async {
+      await pumpSheet(tester, data: meetings);
+
+      expect(find.byType(TextField), findsOneWidget);
+    });
+
+    testWidgets('shows year and month headers and meeting names',
+        (tester) async {
+      final aprilOnly = [
+        makeMeeting(id: 'm1', name: 'Coffee', date: DateTime(2026, 4, 16)),
+        makeMeeting(id: 'm2', name: 'Lunch', date: DateTime(2026, 4, 2)),
+      ];
+      await pumpSheet(tester, data: aprilOnly);
+
+      expect(find.text('2026'), findsOneWidget);
+      expect(find.text('April'), findsOneWidget);
+      expect(find.text('Coffee'), findsOneWidget);
+      expect(find.text('Lunch'), findsOneWidget);
+    });
+
+    testWidgets('tapping a meeting calls onSelected and pops sheet',
+        (tester) async {
+      Meeting? selected;
+      await pumpSheet(tester, data: meetings, onSelected: (m) => selected = m);
+
+      await tester.tap(find.text('Coffee'));
+      await tester.pumpAndSettle();
+
+      expect(selected?.id, 'm1');
+    });
+
+    testWidgets('search by name shows only matching meetings', (tester) async {
+      await pumpSheet(tester, data: meetings);
+
+      await tester.enterText(find.byType(TextField), 'cof');
+      await tester.pump();
+
+      expect(find.text('Coffee'), findsOneWidget);
+      expect(find.text('Lunch'), findsNothing);
+      expect(find.text('Dinner'), findsNothing);
+    });
+
+    testWidgets('search by date shows matching meeting', (tester) async {
+      await pumpSheet(tester, data: meetings);
+
+      await tester.enterText(find.byType(TextField), '16/04/2026');
+      await tester.pump();
+
+      expect(find.text('Coffee'), findsOneWidget);
+      expect(find.text('Lunch'), findsNothing);
+    });
+
+    testWidgets('tapping year header collapses its months', (tester) async {
+      await pumpSheet(tester, data: meetings);
+
+      expect(find.text('April'), findsOneWidget);
+
+      await tester.tap(find.text('2026'));
+      await tester.pump();
+
+      expect(find.text('April'), findsNothing);
+      expect(find.text('Coffee'), findsNothing);
+    });
+
+    testWidgets('shows empty message when search matches nothing',
+        (tester) async {
+      await pumpSheet(tester, data: meetings);
+
+      await tester.enterText(find.byType(TextField), 'zzznomatch');
+      await tester.pump();
+
+      expect(find.text('No meetings found.'), findsOneWidget);
+    });
+  });
+}

--- a/test/presentation/friends_quest/quest_task_tile_test.dart
+++ b/test/presentation/friends_quest/quest_task_tile_test.dart
@@ -15,17 +15,19 @@ void main() {
   Widget wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
 
   group('QuestTaskTile', () {
-    testWidgets('shows task text and read-only checkbox', (tester) async {
+    testWidgets('shows task text and interactive checkbox when incomplete',
+        (tester) async {
       await tester.pumpWidget(wrap(QuestTaskTile(
         task: const FriendsQuestTask(id: 't1', text: 'Buy milk'),
         personMap: const {},
         onEdit: () {},
         onDelete: () {},
+        onComplete: () {},
       )));
 
       expect(find.text('Buy milk'), findsOneWidget);
       final cb = tester.widget<Checkbox>(find.byType(Checkbox));
-      expect(cb.onChanged, isNull);
+      expect(cb.onChanged, isNotNull);
     });
 
     testWidgets('shows assigned person names in subtitle', (tester) async {
@@ -41,6 +43,7 @@ void main() {
         },
         onEdit: () {},
         onDelete: () {},
+        onComplete: () {},
       )));
 
       expect(find.text('Alice, Bob'), findsOneWidget);
@@ -58,6 +61,7 @@ void main() {
         personMap: {'p1': makePerson('p1', 'Alice')},
         onEdit: () {},
         onDelete: () {},
+        onComplete: () {},
       )));
 
       expect(find.text('Alice · Dinner'), findsOneWidget);
@@ -71,6 +75,7 @@ void main() {
         personMap: const {},
         onEdit: () => edited = true,
         onDelete: () => deleted = true,
+        onComplete: () {},
       )));
 
       await tester.tap(find.byIcon(Icons.edit_outlined));
@@ -86,6 +91,7 @@ void main() {
         personMap: const {},
         onEdit: () {},
         onDelete: () {},
+        onComplete: () {},
       )));
 
       final textWidget = tester.widget<Text>(find.text('Done'));

--- a/test/presentation/screens/home_screen_test.dart
+++ b/test/presentation/screens/home_screen_test.dart
@@ -131,6 +131,7 @@ void main() {
       repository: mockFriendsQuestRepository,
       catchUpRepo: mockCatchUpTopicRepository,
       personRepo: mockPersonRepository,
+      meetingRepo: mockMeetingRepository,
     );
     homeProvider = HomeProvider(meetingRepository: mockMeetingRepository);
     buddyWidgetProvider = BuddyWidgetProvider(


### PR DESCRIPTION
## US-126: Friends-Quest Completion & Meeting Link

**As a** user **I want to** link my Friends-Quest to a meeting and complete it
**so that** discussed topics are archived on person profiles and meeting notes updated automatically

### Changes
- `FriendsQuestProvider`: `linkToMeeting`, `completeTask` (archives Catch-up Topic), `completeQuest` (appends completed task texts as meeting notes)
- `MeetingPickerSheet`: grouped collapsible year/month picker with search by name or `dd/mm/yyyy` date
- `FriendsQuestDetailScreen`: complete quest button, meeting link row, interactive task checkboxes
- `QuestTaskTile`: checkbox now interactive for task completion
- `quest_add_task_dialog.dart`: extracted to keep detail screen under 300 lines
- 14 new tests (1029 total)

Closes #303
